### PR TITLE
Fixed syncing of entities that were broken during conversion

### DIFF
--- a/ParseCareKit/CarePlan.swift
+++ b/ParseCareKit/CarePlan.swift
@@ -199,6 +199,10 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                 if reason == "errorMissingColumn"{
                     //Saving the new item with the custom column should resolve the issue
                     print("This table '\(self.parseClassName)' either doesn't exist or is missing a column. Attempting to create the table and add new data to it...")
+                    //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                    if !usingKnowledgeVector{
+                        self.clock = 0
+                    }
                     self.saveAndCheckRemoteID(store,completion: completion)
                 }else{
                     //There was a different issue that we don't know how to handle
@@ -211,8 +215,11 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
             if foundObjects.count > 0{
                 //Maybe this needs to be updated instead
                 self.updateCloud(store, completion: completion)
-                
             }else{
+                //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                if !usingKnowledgeVector{
+                    self.clock = 0
+                }
                 self.saveAndCheckRemoteID(store, completion: completion)
             }
         }

--- a/ParseCareKit/CarePlan.swift
+++ b/ParseCareKit/CarePlan.swift
@@ -43,7 +43,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current(),
             let store = store as? OCKStore else{
             completion(false,nil)
@@ -95,7 +95,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
             let cloudUpdatedAt = parse.locallyUpdatedAt else{
             return
         }
-        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector || overwriteRemote)){
             parse.copyCareKit(careKit, store: store){_ in
                 
                 //An update may occur when Internet isn't available, try to update at some point
@@ -183,7 +183,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current() else{
             return
         }

--- a/ParseCareKit/CarePlan.swift
+++ b/ParseCareKit/CarePlan.swift
@@ -43,7 +43,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current(),
             let store = store as? OCKStore else{
             completion(false,nil)
@@ -66,7 +66,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                             completion(false,nil)
                             return
                         }
-                        self.compareUpdate(carePlan, parse: foundObject, store: store, completion: completion)
+                        self.compareUpdate(carePlan, parse: foundObject, usingKnowledgeVector: usingKnowledgeVector, overwriteRemote: overwriteRemote, store: store, completion: completion)
                         
                     }
                     return
@@ -81,7 +81,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                         completion(false,error)
                         return
                     }
-                    self.compareUpdate(carePlan, parse: foundObject, store: store, completion: completion)
+                    self.compareUpdate(carePlan, parse: foundObject, usingKnowledgeVector: usingKnowledgeVector, overwriteRemote: overwriteRemote, store: store, completion: completion)
                 }
             case .failure(let error):
                 print("Error in Contact.addToCloud(). \(error)")
@@ -90,12 +90,12 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
         
     }
     
-    private func compareUpdate(_ careKit: OCKCarePlan, parse: CarePlan, store: OCKAnyStoreProtocol, completion: @escaping(Bool,Error?) -> Void){
+    private func compareUpdate(_ careKit: OCKCarePlan, parse: CarePlan, usingKnowledgeVector: Bool, overwriteRemote: Bool,  store: OCKAnyStoreProtocol, completion: @escaping(Bool,Error?) -> Void){
         guard let careKitLastUpdated = careKit.updatedDate,
             let cloudUpdatedAt = parse.locallyUpdatedAt else{
             return
         }
-        if cloudUpdatedAt < careKitLastUpdated{
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
             parse.copyCareKit(careKit, store: store){_ in
                 
                 //An update may occur when Internet isn't available, try to update at some point
@@ -111,7 +111,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                 }
             }
             
-        }else if cloudUpdatedAt > careKitLastUpdated {
+        }else if ((cloudUpdatedAt > careKitLastUpdated) || !overwriteRemote) {
             //The cloud version is newer than local, update the local version instead
             guard let updatedCarePlanFromCloud = parse.convertToCareKit() else{
                 completion(false,nil)
@@ -128,6 +128,8 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                     completion(false,error)
                 }
             }
+        }else{
+            completion(true,nil)
         }
     }
     
@@ -181,7 +183,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current() else{
             return
         }
@@ -214,7 +216,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
             //If object already in the Cloud, exit
             if foundObjects.count > 0{
                 //Maybe this needs to be updated instead
-                self.updateCloud(store, completion: completion)
+                self.updateCloud(store, usingKnowledgeVector: usingKnowledgeVector, overwriteRemote: overwriteRemote, completion: completion)
             }else{
                 //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
                 if !usingKnowledgeVector{
@@ -457,7 +459,7 @@ open class CarePlan: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSy
                 guard let parse = copied as? CarePlan else{return}
                 parse.clock = cloudClock //Stamp Entity
                 if careKit.deletedDate == nil{
-                    parse.addToCloud(store, usingKnowledgeVector: true){
+                    parse.addToCloud(store, usingKnowledgeVector: true, overwriteRemote: overwriteRemote){
                         (success,error) in
                         if success{
                             completion(nil)

--- a/ParseCareKit/Contact.swift
+++ b/ParseCareKit/Contact.swift
@@ -212,6 +212,10 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
                 if reason == "errorMissingColumn"{
                     //Saving the new item with the custom column should resolve the issue
                     print("This table '\(self.parseClassName)' either doesn't exist or is missing a column. Attempting to create the table and add new data to it...")
+                    //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                    if !usingKnowledgeVector{
+                        self.clock = 0
+                    }
                     self.saveAndCheckRemoteID(store, completion: completion)
                 }else{
                     //There was a different issue that we don't know how to handle
@@ -224,8 +228,11 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
             if foundObjects.count > 0{
                 //Maybe this needs to be updated instead
                 self.updateCloud(store, completion: completion)
-                
             }else{
+                //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                if !usingKnowledgeVector{
+                    self.clock = 0
+                }
                 self.saveAndCheckRemoteID(store, completion: completion)
             }
         }

--- a/ParseCareKit/Contact.swift
+++ b/ParseCareKit/Contact.swift
@@ -365,14 +365,14 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         
         self.address = CareKitPostalAddress.city.convertToDictionary(contact.address)
         
-        guard let authorID = contact.userInfo?[kPCKContactUserInfoAuthorUserIDKey] else{
+        guard let authorID = contact.userInfo?[kPCKContactUserInfoAuthorUserEntityIdKey] else{
             return
         }
         var query = OCKPatientQuery(for: Date())
         query.ids = [authorID]
         
         var patientRelatedID:String? = nil
-        if let relatedID = contact.userInfo?[kPCKContactUserInfoRelatedUUIDKey] {
+        if let relatedID = contact.userInfo?[kPCKContactUserInfoRelatedEntityIdKey] {
             patientRelatedID = relatedID
             query.ids.append(relatedID)
         }
@@ -396,7 +396,7 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
                     }
                 }else{
                     let userQuery = User.query()!
-                    userQuery.whereKey(kPCKUserIdKey, equalTo: theAuthor.id)
+                    userQuery.whereKey(kPCKUserEntityIdKey, equalTo: theAuthor.id)
                     userQuery.findObjectsInBackground(){
                         (objects, error) in
                         
@@ -438,7 +438,7 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         guard let relatedRemoteId = patient.remoteID else{
             
             let query = User.query()!
-            query.whereKey(kPCKUserIdKey, equalTo: patient.id)
+            query.whereKey(kPCKUserEntityIdKey, equalTo: patient.id)
             query.findObjectsInBackground(){
                 (objects,error) in
                 
@@ -524,11 +524,11 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         contact.source = self.source
         
         var convertedUserInfo = [
-            kPCKContactUserInfoAuthorUserIDKey: self.author.uuid
+            kPCKContactUserInfoAuthorUserEntityIdKey: self.author.entityId
         ]
         
         if let relatedUser = self.user {
-            convertedUserInfo[kPCKContactUserInfoRelatedUUIDKey] = relatedUser.uuid
+            convertedUserInfo[kPCKContactUserInfoRelatedEntityIdKey] = relatedUser.entityId
         }
         
         contact.userInfo = convertedUserInfo

--- a/ParseCareKit/Contact.swift
+++ b/ParseCareKit/Contact.swift
@@ -53,7 +53,7 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current(),
             let store = store as? OCKStore else{
             completion(false,nil)
@@ -109,7 +109,7 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
             completion(false,nil)
             return
         }
-        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector || overwriteRemote)){
             parse.copyCareKit(careKit, store: store){_ in
                 //An update may occur when Internet isn't available, try to update at some point
                 parse.saveAndCheckRemoteID(store){
@@ -198,7 +198,7 @@ open class Contact: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         
         //Check to see if already in the cloud
         let query = Contact.query()!

--- a/ParseCareKit/Outcome.swift
+++ b/ParseCareKit/Outcome.swift
@@ -41,7 +41,7 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         
         guard let _ = User.current(),
             let store = store as? OCKStore else{
@@ -150,7 +150,7 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
             return
         }
         
-        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector || overwriteRemote)){
             deleteOutcomeValueFromCloudIfNeeded(parse.values, careKitValues: careKit.values)
             parse.copyCareKit(careKit, store: store){_ in
                 //An update may occur when Internet isn't available, try to update at some point
@@ -247,7 +247,7 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
             
         guard let _ = User.current() else{
             completion(false,nil)

--- a/ParseCareKit/Outcome.swift
+++ b/ParseCareKit/Outcome.swift
@@ -269,6 +269,10 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
                 if reason == "errorMissingColumn"{
                     //Saving the new item with the custom column should resolve the issue
                     print("This table '\(self.parseClassName)' either doesn't exist or is missing a column. Attempting to create the table and add new data to it...")
+                    //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                    if !usingKnowledgeVector{
+                        self.clock = 0
+                    }
                     self.saveAndCheckRemoteID(store, completion: completion)
                 }else{
                     //There was a different issue that we don't know how to handle
@@ -279,10 +283,13 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
             }
             
             if foundObjects.count > 0{
-                //Maybe this needs to be updated instead added
+                //Maybe this needs to be updated instead of added
                 self.updateCloud(store, completion: completion)
-                
             }else{
+                //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                if !usingKnowledgeVector{
+                    self.clock = 0
+                }
                 //This is the first object, make sure to save it
                 self.saveAndCheckRemoteID(store, completion: completion)
             }

--- a/ParseCareKit/Outcome.swift
+++ b/ParseCareKit/Outcome.swift
@@ -200,7 +200,7 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         //Get latest item from the Cloud to compare against
         let query = Outcome.query()!
         query.whereKey(kPCKOutcomeEntityIdKey, equalTo: entityId)
-        //query.whereKey(kPCKOutcomeIdKey, equalTo: self.uuid)
+        query.includeKeys([kPCKOutcomeValuesKey,kPCKOutcomeNotesKey])
         query.findObjectsInBackground{
             (objects, error) in
             guard let foundObject = objects?.first as? Outcome else{
@@ -219,6 +219,12 @@ open class Outcome: PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSyn
         }
         
         if ((cloudUpdatedAt <= careKitLastUpdated) || usingKnowledgeVector) {
+            parse.values.forEach{
+                $0.deleteInBackground()
+            }
+            parse.notes?.forEach{
+                $0.deleteInBackground()
+            }
             parse.deleteInBackground{
                 (success, error) in
                 if !success{

--- a/ParseCareKit/ParseCareKitConstants.swift
+++ b/ParseCareKit/ParseCareKitConstants.swift
@@ -21,7 +21,7 @@ public let kPCKUserClassKey                                 = User.parseClassNam
 
 // Field keys
 public let kPCKUserObjectIdKey                                    = "objectId"
-public let kPCKUserIdKey                                          = "uuid"
+public let kPCKUserUUIDKey                                          = "uuid"
 public let kPCKUserPostedAtKey                                    = "postedAt"
 public let kPCKUserCreatedAtKey                                   = "createdAt"
 public let kPCKUserUpdatedAtKey                                     = "updatedAt"
@@ -35,7 +35,7 @@ public let kPCKUserSourceKey                                   = "source"
 public let kPCKUserTagsKey                                     = "tags"
 public let kPCKUserTimezoneKey                                 = "timezone"
 public let kPCKUserClockKey                                    = "clock"
-public let kPCKUsereEntityIdKey                                = "entityId"
+public let kPCKUserEntityIdKey                                = "entityId"
 
 
 //#Mark - CarePlan Class
@@ -143,7 +143,8 @@ public let kPCKOutcomeValueObjectIdKey                         = "objectId"
 public let kPCKOutcomeValueCreatedAtKey                           = "createdAt"
 public let kPCKOutcomeValueUpdatedAtKey                           = "updatedAt"
 public let kPCKOutcomeValuePostedAtKey                            = "postedAt"
-public let kPCKOutcomeValueIdKey                                  = "uuid"
+public let kPCKOutcomeValueEntityIdKey                                  = "entityId"
+public let kPCKOutcomeValueUUIDKey                                  = "uuid"
 public let kPCKOutcomeValueIndexKey                               = "index"
 public let kPCKOutcomeValueGroupIdentifierKey                  = "groupIdentifier"
 public let kPCKOutcomeValueKindKey                             = "kind"
@@ -205,8 +206,8 @@ public let kPCKNoteIdKey                                       = "uuid"
 public let kPCKCarePlanUserInfoPatientObjectIdKey           = "patientId"
 
 //Contact Element Class
-public let kPCKContactUserInfoAuthorUserIDKey         = "authorId" //The id of the User if there is one.
-public let kPCKContactUserInfoRelatedUUIDKey          = "relatedId" //The id of the User if there is one.
+public let kPCKContactUserInfoAuthorUserEntityIdKey         = "authorId" //The id of the User if there is one.
+public let kPCKContactUserInfoRelatedEntityIdKey          = "relatedId" //The id of the User if there is one.
 
 //Outcome Class
 public let kPCKOutcomeUserInfoEntityIdKey                   = "entityId"

--- a/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -18,9 +18,13 @@ public protocol PCKRemoteSynchronizedEntity: PFObject, PFSubclassing {
     static func pushRevision(_ store: OCKStore, overwriteRemote: Bool, cloudClock: Int, careKitEntity:OCKEntity, completion: @escaping (Error?) -> Void)
 }
 
+public protocol ParseRemoteSynchronizationDelegate{
+    func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void)
+}
+
 open class ParseRemoteSynchronizationManager: NSObject, OCKRemoteSynchronizable {
     public var delegate: OCKRemoteSynchronizationDelegate?
-    
+    public var parseRemoteDelegate: ParseRemoteSynchronizationDelegate?
     public var automaticallySynchronizes: Bool
     public weak var store:OCKStore!
     
@@ -208,7 +212,11 @@ open class ParseRemoteSynchronizationManager: NSObject, OCKRemoteSynchronizable 
     }
     
     public func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
-        let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
-        completion(conflictPolicy)
+        if parseRemoteDelegate != nil{
+            parseRemoteDelegate!.chooseConflictResolutionPolicy(conflict, completion: completion)
+        }else{
+            let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
+            completion(conflictPolicy)
+        }
     }
 }

--- a/ParseCareKit/ParseSynchronizedStoreManager.swift
+++ b/ParseCareKit/ParseSynchronizedStoreManager.swift
@@ -15,8 +15,8 @@ import Parse
  Protocol that defines the properties and methods for parse carekit entities that are synchronized using a wall clock.
  */
 public protocol PCKSynchronizedEntity: PFObject, PFSubclassing {
-    func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool, completion: @escaping(Bool,Error?) -> Void)
-    func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool, completion: @escaping(Bool,Error?) -> Void)
+    func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool, overwriteRemote: Bool, completion: @escaping(Bool,Error?) -> Void)
+    func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool, overwriteRemote: Bool, completion: @escaping(Bool,Error?) -> Void)
     func deleteFromCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool, completion: @escaping(Bool,Error?) -> Void)
 }
 

--- a/ParseCareKit/ScheduleElement.swift
+++ b/ParseCareKit/ScheduleElement.swift
@@ -226,34 +226,30 @@ open class ScheduleElement: PFObject, PFSubclassing {
     }
     
     class func convertCareKitArrayToParse(_ values: [OCKScheduleElement], store: OCKAnyStoreProtocol, completion: @escaping([ScheduleElement]) -> Void){
-        
         var returnValues = [ScheduleElement]()
-        
         if values.isEmpty{
             completion(returnValues)
             return
         }
-        
-        for (index,value) in values.enumerated(){
-    
-            let _ = ScheduleElement(careKitEntity: value, store: store){
+        var numberOfCopiedElements = 0
+        values.forEach{
+            let _ = ScheduleElement(careKitEntity: $0, store: store){
                 newElement in
-                
+                numberOfCopiedElements += 1
                 guard let newScheduleElement = newElement else{
                     return
                 }
-                newScheduleElement.copyCareKit(value, store: store){
-                    (valueCopied) in
-                
-                    returnValues.append(valueCopied)
-                    
+                let careKitElements = newScheduleElement.elements.compactMap{$0.convertToCareKit()}
+                ScheduleElement.convertCareKitArrayToParse(careKitElements, store: store){
+                    moreElements in
+                    newScheduleElement.elements = moreElements
+                    returnValues.append(newScheduleElement)
                     //copyCareKit is async, so we need it to tell us when it's finished
-                    if index == (values.count-1){
+                    if numberOfCopiedElements == (values.count){
                         completion(returnValues)
                     }
                 }
             }
-            
         }
     }
 }

--- a/ParseCareKit/Task.swift
+++ b/ParseCareKit/Task.swift
@@ -45,7 +45,7 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current(),
             let store = store as? OCKStore else{
             completion(false,nil)
@@ -100,7 +100,7 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
             return
         }
     
-        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector || overwriteRemote)){
             parse.copyCareKit(careKit, store: store){_ in
                 //An update may occur when Internet isn't available, try to update at some point
                 parse.saveAndCheckRemoteID(store){
@@ -195,7 +195,7 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current()else{
             completion(false,nil)
             return

--- a/ParseCareKit/Task.swift
+++ b/ParseCareKit/Task.swift
@@ -147,6 +147,7 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
         //Get latest item from the Cloud to compare against
         let query = Task.query()!
         query.whereKey(kPCKTaskEntityIdKey, equalTo: self.entityId)
+        query.includeKeys([kPCKTaskElementsKey,kPCKTaskNotesKey])
         query.getFirstObjectInBackground(){
             (objects, error) in
             guard let foundObject = objects as? Task else{
@@ -165,6 +166,12 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
         }
         
         if ((cloudUpdatedAt <= careKitLastUpdated) || usingKnowledgeVector){
+            parse.elements.forEach{
+                $0.deleteInBackground()
+            }
+            parse.notes?.forEach{
+                $0.deleteInBackground()
+            }
             parse.deleteInBackground{
                 (success, error) in
                 if !success{

--- a/ParseCareKit/Task.swift
+++ b/ParseCareKit/Task.swift
@@ -218,6 +218,10 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
                 if reason == "errorMissingColumn"{
                     //Saving the new item with the custom column should resolve the issue
                     print("This table '\(self.parseClassName)' either doesn't exist or is missing a column. Attempting to create the table and add new data to it...")
+                    //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                    if !usingKnowledgeVector{
+                        self.clock = 0
+                    }
                     self.saveAndCheckRemoteID(store, completion: completion)
                 }else{
                     //There was a different issue that we don't know how to handle
@@ -229,9 +233,13 @@ open class Task : PFObject, PFSubclassing, PCKSynchronizedEntity, PCKRemoteSynch
             
             //If object already in the Cloud, exit
             if foundObjects.count > 0{
-                //Maybe this needs to be updated instead
+                //Maybe this needs to be updated of instead
                 self.updateCloud(store, completion: completion)
             }else{
+                //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                if !usingKnowledgeVector{
+                    self.clock = 0
+                }
                 self.saveAndCheckRemoteID(store, completion: completion)
             }
         }

--- a/ParseCareKit/User.swift
+++ b/ParseCareKit/User.swift
@@ -207,6 +207,10 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
                 if reason == "errorMissingColumn"{
                     //Saving the new item with the custom column should resolve the issue
                     print("This table '\(self.parseClassName)' either doesn't exist or is missing a column. Attempting to create the table and add new data to it...")
+                    //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                    if !usingKnowledgeVector{
+                        self.clock = 0
+                    }
                     self.saveAndCheckRemoteID(store, completion: completion)
                 }else{
                     //There was a different issue that we don't know how to handle
@@ -220,6 +224,10 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
                 //Maybe this needs to be updated instead
                 self.updateCloud(store, completion: completion)
             }else{
+                //Make wallclock level entities compatible with KnowledgeVector by setting it's initial clock to 0
+                if !usingKnowledgeVector{
+                    self.clock = 0
+                }
                 self.saveAndCheckRemoteID(store, completion: completion)
             }
         }

--- a/ParseCareKit/User.swift
+++ b/ParseCareKit/User.swift
@@ -42,7 +42,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
             return
         }
         
-        store.fetchPatient(withID: self.uuid, callbackQueue: .global(qos: .background)){
+        store.fetchPatient(withID: self.entityId, callbackQueue: .global(qos: .background)){
             result in
             switch result{
             case .success(let patient):
@@ -50,7 +50,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
                     
                     //Check to see if this entity is already in the Cloud, but not paired locally
                     let query = User.query()!
-                    query.whereKey(kPCKUserIdKey, equalTo: patient.id)
+                    query.whereKey(kPCKUserEntityIdKey, equalTo: patient.id)
                     query.findObjectsInBackground{
                         (objects, error) in
                         
@@ -147,7 +147,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
         
         //Get latest item from the Cloud to compare against
         let query = User.query()!
-        query.whereKey(kPCKUserIdKey, equalTo: self.uuid)
+        query.whereKey(kPCKUserEntityIdKey, equalTo: self.entityId)
         query.getFirstObjectInBackground(){
             (objects, error) in
             
@@ -198,7 +198,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
 
         //Check to see if already in the cloud
         let query = User.query()!
-        query.whereKey(kPCKUserIdKey, equalTo: self.uuid)
+        query.whereKey(kPCKUserEntityIdKey, equalTo: self.entityId)
         query.findObjectsInBackground(){
             (objects, error) in
             guard let foundObjects = objects else{
@@ -242,7 +242,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
             if success{
                 print("Successfully saved \(self) in Cloud.")
                 //Only save data back to CarePlanStore if it's never been saved before
-                store.fetchPatient(withID: self.uuid, callbackQueue: .global(qos: .background)){
+                store.fetchPatient(withID: self.entityId, callbackQueue: .global(qos: .background)){
                     result in
                     switch result{
                     case .success(var mutableEntity):

--- a/ParseCareKit/User.swift
+++ b/ParseCareKit/User.swift
@@ -35,7 +35,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
         self.copyCareKit(careKitEntity, store: store, completion: completion)
     }
     
-    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func updateCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current(),
             let store = store as? OCKStore else{
             completion(false,nil)
@@ -102,7 +102,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
             }
             return
         }
-        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector && overwriteRemote)){
+        if ((cloudUpdatedAt < careKitLastUpdated) || (usingKnowledgeVector || overwriteRemote)){
             parse.copyCareKit(careKit, store: store){
                 _ in
                 //An update may occur when Internet isn't available, try to update at some point
@@ -191,7 +191,7 @@ open class User: PFUser, PCKSynchronizedEntity, PCKRemoteSynchronizedEntity {
         }
     }
     
-    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=true, completion: @escaping(Bool,Error?) -> Void){
+    open func addToCloud(_ store: OCKAnyStoreProtocol, usingKnowledgeVector:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         guard let _ = User.current() else{
             return
         }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For details on how to setup parse-server, follow the directions [here](https://g
 ### Protecting Patients data in the Cloud using ACL's
 You should set the default access for information you placed on your parse-server using ParseCareKit. To do this, you can set the default read/write access for all classes. For example, to make all data created to only be read and written by the user who created at do the following in your AppDelegate:
 
-```
+```swift
 PFUser.enableRevocableSessionInBackground() //Allow sessions to be revovked from the cloud
 
 //Set default ACL for all Classes

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Follow the [guide](https://docs.parseplatform.org/ios/guide/) for directions on 
 ## Setup Parse Server
 For details on how to setup parse-server, follow the directions [here](https://github.com/parse-community/parse-server#getting-started) or look at their detailed [guide](https://docs.parseplatform.org/parse-server/guide/). Note that standard deployment locally on compouter, docker, AWS, Google Cloud, isn't HIPAA complaint by default. 
 
+### Protecting Patients data in the Cloud using ACL's
+You should set the default access for information you placed on your parse-server using ParseCareKit. To do this, you can set the default read/write access for all classes. For example, to make all data created to only be read and written by the user who created at do the following in your AppDelegate:
+
+```
+PFUser.enableRevocableSessionInBackground() //Allow sessions to be revovked from the cloud
+
+//Set default ACL for all Classes
+let defaultACL = PFACL()
+defaultACL.hasPublicReadAccess = false
+defaultACL.hasPublicWriteAccess = false
+PFACL.setDefault(defaultACL, withAccessForCurrentUser:true)
+```
+
+When giving access to a CareTeam or other entities, special care should be taken when deciding the propper ACL or Role. Feel free to read more about [ACLs](https://docs.parseplatform.org/ios/guide/#security-for-user-objects) and [Role](https://docs.parseplatform.org/ios/guide/#roles) access in Parse.
+
 ## Synchronizing Your Data
 Assuming you are already familiar with [CareKit](https://github.com/carekit-apple/CareKit) (look at their documentation for details). Using ParseCareKit is simple, especially if you are using `OCKStore` out-of-the-box. If you are using a custom `OCKStore` you will need to subclass and write some additional code to synchronize your care-store with parse-server.
 


### PR DESCRIPTION
Entities like Patient, Contact, and CarePlan were broken when changing over to uuid. These are now fixed