### PR TITLE
Fix versioning of OCKEntities

### DIFF
--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -279,9 +279,9 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     }
 
     func prepareEncodingRelational(_ encodingForParse: Bool) {
-        previousVersion?.encodingForParse = encodingForParse
+        /*previousVersion?.encodingForParse = encodingForParse
         nextVersion?.encodingForParse = encodingForParse
-        patient?.encodingForParse = encodingForParse
+        patient?.encodingForParse = encodingForParse*/
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -298,9 +298,9 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
     }
     
     func prepareEncodingRelational(_ encodingForParse: Bool) {
-        previousVersion?.encodingForParse = encodingForParse
+        /*previousVersion?.encodingForParse = encodingForParse
         nextVersion?.encodingForParse = encodingForParse
-        carePlan?.encodingForParse = encodingForParse
+        carePlan?.encodingForParse = encodingForParse*/
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -292,7 +292,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
     }
         
     public func prepareEncodingRelational(_ encodingForParse: Bool) {
-        task?.encodingForParse = encodingForParse
+        //task?.encodingForParse = encodingForParse
         values?.forEach {
             $0.encodingForParse = encodingForParse
         }

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -285,8 +285,8 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     }
 
     func prepareEncodingRelational(_ encodingForParse: Bool) {
-        previousVersion?.encodingForParse = encodingForParse
-        nextVersion?.encodingForParse = encodingForParse
+        /*previousVersion?.encodingForParse = encodingForParse
+        nextVersion?.encodingForParse = encodingForParse*/
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -292,9 +292,9 @@ public final class Task: PCKVersionable, PCKSynchronizable {
     }
 
     func prepareEncodingRelational(_ encodingForParse: Bool) {
-        previousVersion?.encodingForParse = encodingForParse
+        /*previousVersion?.encodingForParse = encodingForParse
         nextVersion?.encodingForParse = encodingForParse
-        carePlan?.encodingForParse = encodingForParse
+        carePlan?.encodingForParse = encodingForParse*/
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -139,12 +139,12 @@ extension PCKObjectable {
     }
     
     public func find(_ uuid:UUID?, include:Bool=true,
-                         completion: @escaping([Self]?,Error?) -> Void) {
+                         completion: @escaping(Result<[Self],Error>) -> Void) {
           
         guard let _ = PCKUser.current,
-            let uuidString = uuid?.uuidString else{
+            let uuidString = uuid?.uuidString else {
                 print("Error in \(self.className).find(). \(ParseCareKitError.requiredValueCantBeUnwrapped)")
-                completion(nil,ParseCareKitError.couldntUnwrapClock)
+                completion(.failure(ParseCareKitError.couldntUnwrapClock))
                 return
         }
             
@@ -156,10 +156,10 @@ extension PCKObjectable {
             switch results {
             
             case .success(let foundObjects):
-                completion(foundObjects, nil)
+                completion(.success(foundObjects))
             case .failure(let error):
                 print("Error in \(self.className).find(). \(error.localizedDescription)")
-                completion(nil,error)
+                completion(.failure(error))
             }
             
         }

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -51,7 +51,7 @@ extension PCKVersionable {
             (isNew,previousObject) in
             
             guard let previousObject  = previousObject else{
-                completion(false, versionedObject)
+                completion(linkedNew, versionedObject)
                 return
             }
             
@@ -64,7 +64,7 @@ extension PCKVersionable {
                 (isNew,nextObject) in
                 
                 guard let nextObject  = nextObject else{
-                    completion(false,versionedObject)
+                    completion(linkedNew,versionedObject)
                     return
                 }
                 
@@ -162,43 +162,6 @@ extension PCKVersionable {
 
     public func save(completion: @escaping(Bool, Error?) -> Void) {
         var versionedObject = self
-        /*switch versionedObject{
-        case is CarePlan:
-            
-            guard let versionedObject = versionedObject as? CarePlan else{
-                completion(false,ParseCareKitError.cantCastToNeededClassType)
-                return
-            }
-            
-            _ = versionedObject.stampRelationalEntities()
-            
-        case is Contact:
-            guard let versionedObject = versionedObject as? Contact else{
-                completion(false,ParseCareKitError.cantCastToNeededClassType)
-                return
-            }
-            
-            _ = versionedObject.stampRelationalEntities()
-
-        case is Patient:
-            guard let versionedObject = versionedObject as? Patient else{
-                completion(false,ParseCareKitError.cantCastToNeededClassType)
-                return
-            }
-            
-            _ = versionedObject.stampRelationalEntities()
-
-        case is Task:
-            guard let versionedObject = versionedObject as? Task else{
-                completion(false,ParseCareKitError.cantCastToNeededClassType)
-                return
-            }
-            
-            _ = versionedObject.stampRelationalEntities()
-
-        default:
-            completion(false,ParseCareKitError.classTypeNotAnEligibleType)
-        }*/
         _ = try? versionedObject.stampRelationalEntities()
         versionedObject.save(callbackQueue: .global(qos: .background)){ results in
             switch results {
@@ -307,6 +270,9 @@ extension PCKVersionable {
         var container = encoder.container(keyedBy: PCKCodingKeys.self)
         
         if encodingForParse {
+            if nextVersion != nil {
+                print(nextVersion)
+            }
             try container.encodeIfPresent(nextVersion, forKey: .nextVersion)
             try container.encodeIfPresent(previousVersion, forKey: .previousVersion)
             

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -177,9 +177,10 @@ extension PCKVersionable {
                     
                     //Fix versioning doubly linked list if it's broken in the cloud
                     if modifiedObject.previousVersion != nil {
-                        if modifiedObject.previousVersion!.nextVersion == nil{
-                            modifiedObject.previousVersion!.nextVersion = modifiedObject
-                            modifiedObject.previousVersion!.save(callbackQueue: .global(qos: .background)){ results in
+                        if modifiedObject.previousVersion!.nextVersion == nil {
+                            var previousVersionToUpdate = modifiedObject.previousVersion!
+                            previousVersionToUpdate.nextVersion = modifiedObject
+                            previousVersionToUpdate.save(callbackQueue: .global(qos: .background)){ results in
                                 switch results {
                                     
                                 case .success(_):

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -187,7 +187,7 @@ extension PCKVersionable {
                                     guard var previousObjectFound = versionedObjectsFound.first else {
                                         return
                                     }
-                                    previousObjectFound = modifiedObject
+                                    previousObjectFound.nextVersion = modifiedObject
                                     previousObjectFound.save(callbackQueue: .global(qos: .background)){ results in
                                         switch results {
                                             

--- a/TestHost/Info.plist
+++ b/TestHost/Info.plist
@@ -18,6 +18,11 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -87,12 +87,13 @@ class ParseCareKitTests: XCTestCase {
         userLogin()
         //userLoginToRealServer()
         do {
-            parse = try ParseRemoteSynchronizationManager(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false)
+        parse = try ParseRemoteSynchronizationManager(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false)
         } catch {
             print(error.localizedDescription)
         }
         store = OCKStore(name: "SampleAppStore", type: .onDisk, remote: parse)
         parse?.parseRemoteDelegate = self
+        
     }
 
     override func tearDownWithError() throws {
@@ -832,7 +833,8 @@ class ParseCareKitTests: XCTestCase {
         let contact = OCKContact(id: "test", givenName: "hello", familyName: "world", carePlanUUID: nil)
         var savedContact = try store.addContactAndWait(contact)
         //savedContact.title = "me"
-        //try self.store.updateContactAndWait(savedContact)
+        //parse.automaticallySynchronizes = true
+        try self.store.updateContactAndWait(savedContact)
         /*
         let revision = store.computeRevision(since: 0)
         XCTAssert(revision.entities.count == 1)


### PR DESCRIPTION
Fixed a bug that caused a crash in ParseCareKit after an update on a versioned object occurred.