### PR TITLE
Fix decoding of ParseCareKit entities when they come from the server

### DIFF
--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -328,10 +328,10 @@ extension CarePlan {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if encodingForParse {
-            try container.encode(patient, forKey: .patient)
+            try container.encodeIfPresent(patient, forKey: .patient)
         }
         try container.encode(title, forKey: .title)
-        try container.encode(patientUUID, forKey: .patientUUID)
+        try container.encodeIfPresent(patientUUID, forKey: .patientUUID)
         try encodeVersionable(to: encoder)
         encodingForParse = true
     }

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -105,7 +105,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUID, nextVersionUUID, effectiveDate
         case title, patient, patientUUID
     }

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -311,6 +311,12 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.encoder().encode(self)
         self.encodingForParse = true
+        do {
+            let test = try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
+            print(test)
+        } catch {
+            print(error.localizedDescription)
+        }
         return try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -311,12 +311,6 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.encoder().encode(self)
         self.encodingForParse = true
-        do {
-            let test = try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
-            print(test)
-        } catch {
-            print(error.localizedDescription)
-        }
         return try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -355,20 +355,20 @@ extension Contact {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         if encodingForParse {
-            try container.encode(carePlan, forKey: .carePlan)
+            try container.encodeIfPresent(carePlan, forKey: .carePlan)
         }
         
-        try container.encode(title, forKey: .title)
-        try container.encode(carePlanUUID, forKey: .carePlanUUID)
-        try container.encode(address, forKey: .address)
-        try container.encode(category, forKey: .category)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(carePlanUUID, forKey: .carePlanUUID)
+        try container.encodeIfPresent(address, forKey: .address)
+        try container.encodeIfPresent(category, forKey: .category)
         try container.encode(name, forKey: .name)
-        try container.encode(organization, forKey: .organization)
-        try container.encode(role, forKey: .role)
-        try container.encode(emailAddresses, forKey: .emailAddresses)
-        try container.encode(messagingNumbers, forKey: .messagingNumbers)
-        try container.encode(phoneNumbers, forKey: .phoneNumbers)
-        try container.encode(otherContactInfo, forKey: .otherContactInfo)
+        try container.encodeIfPresent(organization, forKey: .organization)
+        try container.encodeIfPresent(role, forKey: .role)
+        try container.encodeIfPresent(emailAddresses, forKey: .emailAddresses)
+        try container.encodeIfPresent(messagingNumbers, forKey: .messagingNumbers)
+        try container.encodeIfPresent(phoneNumbers, forKey: .phoneNumbers)
+        try container.encodeIfPresent(otherContactInfo, forKey: .otherContactInfo)
         try encodeVersionable(to: encoder)
         encodingForParse = true
     }

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -117,7 +117,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUID, nextVersionUUID, effectiveDate
         case carePlan, title, carePlanUUID, address, category, name, organization, role
         case emailAddresses, messagingNumbers, phoneNumbers, otherContactInfo

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -427,8 +427,8 @@ extension Outcome {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if encodingForParse {
-            try container.encode(task, forKey: .task)
-            try container.encode(date, forKey: .date)
+            try container.encodeIfPresent(task, forKey: .task)
+            try container.encodeIfPresent(date, forKey: .date)
         }
         try container.encode(taskUUID, forKey: .taskUUID)
         try container.encode(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -105,10 +105,10 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(allergies, forKey: .allergies)
-        try container.encode(birthday, forKey: .birthday)
+        try container.encodeIfPresent(allergies, forKey: .allergies)
+        try container.encodeIfPresent(birthday, forKey: .birthday)
         try container.encode(name, forKey: .name)
-        try container.encode(sex, forKey: .sex)
+        try container.encodeIfPresent(sex, forKey: .sex)
         try encodeVersionable(to: encoder)
     }
     

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -98,7 +98,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUID, nextVersionUUID, effectiveDate
         case allergies, birthday, name, sex
     }

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -352,10 +352,10 @@ extension Task {
         if encodingForParse {
             try container.encode(carePlan, forKey: .carePlan)
         }
-        try container.encode(title, forKey: .title)
-        try container.encode(carePlanUUID, forKey: .carePlanUUID)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(carePlanUUID, forKey: .carePlanUUID)
         try container.encode(impactsAdherence, forKey: .impactsAdherence)
-        try container.encode(instructions, forKey: .instructions)
+        try container.encodeIfPresent(instructions, forKey: .instructions)
         try container.encode(schedule, forKey: .schedule)
         try encodeVersionable(to: encoder)
         encodingForParse = true

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -107,7 +107,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUID, nextVersionUUID, effectiveDate
         case title, carePlan, carePlanUUID, impactsAdherence, instructions, schedule
     }

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -197,7 +197,7 @@ extension PCKObjectable {
         var container = encoder.container(keyedBy: PCKCodingKeys.self)
         
         if encodingForParse {
-            if !(self is Note) {
+            if !(self is Note) || !(self is OutcomeValue) {
                 try container.encodeIfPresent(entityId, forKey: .entityId)
             }
             try container.encodeIfPresent(ACL, forKey: .ACL)

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -10,7 +10,6 @@ import XCTest
 @testable import ParseCareKit
 @testable import CareKitStore
 @testable import ParseSwift
-import Contacts
 
 struct LoginSignupResponse: ParseUser {
     var objectId: String?
@@ -716,40 +715,6 @@ class ParseCareKitTests: XCTestCase {
     }
 
     func testContact() throws {
-        var careKit = OCKContact(id: "matthew", givenName: "Matthew",
-                                 familyName: "Reiff", carePlanUUID: nil)
-        careKit.asset = "MatthewReiff"
-        careKit.title = "OBGYN"
-        careKit.role = "Dr. Reiff is an OBGYN with 13 years of experience."
-        careKit.phoneNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-1000")]
-        careKit.messagingNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-1234")]
-        careKit.address = {
-           let address = OCKPostalAddress()
-           address.street = "1000 S Limestone"
-           address.city = "Lexington"
-           address.state = "KY"
-           address.postalCode = "40536"
-           return address
-        }()
-
-        /*var careKit = OCKContact(id: "jane", givenName: "Jane",
-                                 familyName: "Daniels", carePlanUUID: nil)
-        careKit.asset = "JaneDaniels"
-        careKit.title = "Family Practice Doctor"
-        careKit.role = "Dr. Daniels is a family practice doctor with 8 years of experience."
-        careKit.emailAddresses = [OCKLabeledValue(label: CNLabelEmailiCloud, value: "janedaniels@uky.edu")]
-        careKit.phoneNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-2000")]
-        careKit.messagingNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 357-2040")]
-
-        careKit.address = {
-           let address = OCKPostalAddress()
-           address.street = "2195 Harrodsburg Rd"
-           address.city = "Lexington"
-           address.state = "KY"
-           address.postalCode = "40504"
-           return address
-        }()*/
-        /*
         var careKit = OCKContact(id: "myId", givenName: "hello", familyName: "world", carePlanUUID: UUID())
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
 
@@ -784,7 +749,7 @@ class ParseCareKitTests: XCTestCase {
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
-        careKit.effectiveDate = Date().addingTimeInterval(-199)*/
+        careKit.effectiveDate = Date().addingTimeInterval(-199)
         
         //Test CareKit -> Parse
         let parse = try Contact.copyCareKit(careKit)

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import ParseCareKit
 @testable import CareKitStore
 @testable import ParseSwift
+import Contacts
 
 struct LoginSignupResponse: ParseUser {
     var objectId: String?
@@ -715,6 +716,40 @@ class ParseCareKitTests: XCTestCase {
     }
 
     func testContact() throws {
+        var careKit = OCKContact(id: "matthew", givenName: "Matthew",
+                                 familyName: "Reiff", carePlanUUID: nil)
+        careKit.asset = "MatthewReiff"
+        careKit.title = "OBGYN"
+        careKit.role = "Dr. Reiff is an OBGYN with 13 years of experience."
+        careKit.phoneNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-1000")]
+        careKit.messagingNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-1234")]
+        careKit.address = {
+           let address = OCKPostalAddress()
+           address.street = "1000 S Limestone"
+           address.city = "Lexington"
+           address.state = "KY"
+           address.postalCode = "40536"
+           return address
+        }()
+
+        /*var careKit = OCKContact(id: "jane", givenName: "Jane",
+                                 familyName: "Daniels", carePlanUUID: nil)
+        careKit.asset = "JaneDaniels"
+        careKit.title = "Family Practice Doctor"
+        careKit.role = "Dr. Daniels is a family practice doctor with 8 years of experience."
+        careKit.emailAddresses = [OCKLabeledValue(label: CNLabelEmailiCloud, value: "janedaniels@uky.edu")]
+        careKit.phoneNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 257-2000")]
+        careKit.messagingNumbers = [OCKLabeledValue(label: CNLabelWork, value: "(859) 357-2040")]
+
+        careKit.address = {
+           let address = OCKPostalAddress()
+           address.street = "2195 Harrodsburg Rd"
+           address.city = "Lexington"
+           address.state = "KY"
+           address.postalCode = "40504"
+           return address
+        }()*/
+        /*
         var careKit = OCKContact(id: "myId", givenName: "hello", familyName: "world", carePlanUUID: UUID())
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
 
@@ -749,7 +784,7 @@ class ParseCareKitTests: XCTestCase {
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
-        careKit.effectiveDate = Date().addingTimeInterval(-199)
+        careKit.effectiveDate = Date().addingTimeInterval(-199)*/
         
         //Test CareKit -> Parse
         let parse = try Contact.copyCareKit(careKit)


### PR DESCRIPTION
This PR fixes a bug where the `entityId` wasn't being decoded from the server. This bug is only present when using ParseSwift.

In addition, the ParseEntities are updated to use encodeIfPresent for optional properties that don't need to be encoded.