### PR TITLE
Fix decoding error when syncing for first time

### DIFF
--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -128,6 +128,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         }
         
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
         query.first(callbackQueue: .global(qos: .background)){
             result in
             
@@ -159,7 +160,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousCarePlanUUID]))
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
         query.find(callbackQueue: .main) {
             results in
             
@@ -201,8 +202,8 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     public func pullRevisions(_ localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
-        _ = query.order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-        _ = query.includeAll()
+            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -128,7 +128,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         }
         
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)){
             result in
             
@@ -167,7 +167,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousCarePlanUUID]))
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
+            .includeAll()
         query.find(callbackQueue: .main) {
             results in
             
@@ -210,7 +210,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKCarePlanPatientKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -134,8 +134,15 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
             
             switch result {
             
-            case .success(_):
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+            case .success(let foundEntity):
+                guard foundEntity.entityId == self.entityId else {
+                    //This object has a duplicate uuid but isn't the same object
+                    completion(false,ParseCareKitError.uuidAlreadyExists)
+                    return
+                }
+                //This object already exists on server, ignore gracefully
+                completion(true,ParseCareKitError.uuidAlreadyExists)
+
             case .failure(let error):
 
                 switch error.code {

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -144,6 +144,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Contact.query(kPCKObjectableUUIDKey == uuid)
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -174,7 +175,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Contact.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -214,8 +215,8 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
     public func pullRevisions(_ localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
         let query = Contact.query(kPCKObjectableClockKey >= localClock)
-        _ = query.order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-        _ = query.includeAll()
+            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -149,8 +149,14 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
             
             switch result {
             
-            case .success(_):
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+            case .success(let foundEntity):
+                guard foundEntity.entityId == self.entityId else {
+                    //This object has a duplicate uuid but isn't the same object
+                    completion(false,ParseCareKitError.uuidAlreadyExists)
+                    return
+                }
+                //This object already exists on server, ignore gracefully
+                completion(true,ParseCareKitError.uuidAlreadyExists)
 
             case .failure(let error):
                 switch error.code {

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -144,7 +144,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Contact.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -181,7 +181,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Contact.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -222,7 +222,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         let query = Contact.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKContactCarePlanKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -135,7 +135,7 @@ open class Note: PCKObjectable {
             return
         }
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: uuids))
-            .include([kPCKObjectableNotesKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -135,6 +135,7 @@ open class Note: PCKObjectable {
             return
         }
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: uuids))
+            .include([kPCKObjectableNotesKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,21 +105,13 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
             
-            case .success(let foundEntity):
-                guard foundEntity.createdDate == self.createdDate,
-                      foundEntity.updatedDate == self.updatedDate,
-                      foundEntity.deletedDate == self.deletedDate,
-                      foundEntity.id == self.id else {
-                    //A different entity with the same uuid exists
-                        completion(false,ParseCareKitError.uuidAlreadyExists)
-                        return
-                      }
-                //This entity is already synced, skip
-                completion(true,ParseCareKitError.uuidAlreadyExists)
+            case .success(_):
+                completion(false,ParseCareKitError.uuidAlreadyExists)
             case .failure(let error):
                 switch error.code{
                 case .internalServer: //1 - this column hasn't been added.
@@ -129,7 +121,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                         return
                     }
                     let query = Outcome.query(kPCKObjectableEntityIdKey == self.id, doesNotExist(key: kPCKObjectableDeletedDateKey))
-                    _ = query.includeAll()
+                        .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
                     query.first(callbackQueue: .global(qos: .background)){ result in
                         
                         switch result {
@@ -229,7 +221,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                 
         //Get latest item from the Cloud to compare against
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-        _ = query.includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -408,7 +400,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         let taskQuery = Task.query(doesNotExist(key: kPCKObjectableDeletedDateKey))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
         let query = Outcome.query(doesNotExist(key: kPCKObjectableDeletedDateKey), matchesKeyInQuery(key: kPCKOutcomeTaskKey, queryKey: kPCKOutcomeTaskKey, query: taskQuery))
-        _ = query.includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         return query
     }
    

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -117,7 +117,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                     return
                 }
                 //This object already exists on server, ignore gracefully
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+                completion(true,ParseCareKitError.uuidAlreadyExists)
             case .failure(let error):
                 switch error.code{
                 case .internalServer: //1 - this column hasn't been added.

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,13 +105,13 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
             
             case .success(let foundEntity):
-                guard foundEntity.id == self.id else {
+                guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(false,ParseCareKitError.uuidAlreadyExists)
                     return

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -106,7 +106,6 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
             .includeAll()
-            //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -128,7 +127,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                         return
                     }
                     let query = Outcome.query(kPCKObjectableEntityIdKey == self.id, doesNotExist(key: kPCKObjectableDeletedDateKey))
-                        .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+                        .includeAll()
                     query.first(callbackQueue: .global(qos: .background)){ result in
                         
                         switch result {
@@ -167,7 +166,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             switch results {
             
@@ -228,7 +227,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                 
         //Get latest item from the Cloud to compare against
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -407,7 +406,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         let taskQuery = Task.query(doesNotExist(key: kPCKObjectableDeletedDateKey))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
         let query = Outcome.query(doesNotExist(key: kPCKObjectableDeletedDateKey), matchesKeyInQuery(key: kPCKOutcomeTaskKey, queryKey: kPCKOutcomeTaskKey, query: taskQuery))
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .includeAll()
         return query
     }
    

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,6 +105,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
+            .includeAll()
             //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -109,8 +109,17 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
             
             switch result {
             
-            case .success(_):
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+            case .success(let foundEntity):
+                guard foundEntity.createdDate == self.createdDate,
+                      foundEntity.updatedDate == self.updatedDate,
+                      foundEntity.deletedDate == self.deletedDate,
+                      foundEntity.id == self.id else {
+                    //A different entity with the same uuid exists
+                        completion(false,ParseCareKitError.uuidAlreadyExists)
+                        return
+                      }
+                //This entity is already synced, skip
+                completion(true,ParseCareKitError.uuidAlreadyExists)
             case .failure(let error):
                 switch error.code{
                 case .internalServer: //1 - this column hasn't been added.

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -110,7 +110,13 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
             
             switch result {
             
-            case .success(_):
+            case .success(let foundEntity):
+                guard foundEntity.id == self.id else {
+                    //This object has a duplicate uuid but isn't the same object
+                    completion(false,ParseCareKitError.uuidAlreadyExists)
+                    return
+                }
+                //This object already exists on server, ignore gracefully
                 completion(false,ParseCareKitError.uuidAlreadyExists)
             case .failure(let error):
                 switch error.code{

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -75,7 +75,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
     

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -132,7 +132,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
 
         //Check to see if already in the cloud
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
            
             switch result {
@@ -164,7 +164,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not paired locally
         let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -206,8 +206,8 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     public func pullRevisions(_ localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
-        _ = query.order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-        _ = query.includeAll()
+            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -132,7 +132,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
 
         //Check to see if already in the cloud
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)){ result in
            
             switch result {
@@ -171,7 +171,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not paired locally
         let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -214,7 +214,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -137,8 +137,15 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
            
             switch result {
             
-            case .success(_):
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+            case .success(let foundEntity):
+                guard foundEntity.entityId == self.entityId else {
+                    //This object has a duplicate uuid but isn't the same object
+                    completion(false,ParseCareKitError.uuidAlreadyExists)
+                    return
+                }
+                //This object already exists on server, ignore gracefully
+                completion(true,ParseCareKitError.uuidAlreadyExists)
+
             case .failure(let error):
                 
                 switch error.code{

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -137,8 +137,15 @@ public final class Task: PCKVersionable, PCKSynchronizable {
             
             switch result {
             
-            case .success(_):
-                completion(false,ParseCareKitError.uuidAlreadyExists)
+            case .success(let foundEntity):
+                guard foundEntity.entityId == self.entityId else {
+                    //This object has a duplicate uuid but isn't the same object
+                    completion(false,ParseCareKitError.uuidAlreadyExists)
+                    return
+                }
+                //This object already exists on server, ignore gracefully
+                completion(true,ParseCareKitError.uuidAlreadyExists)
+
             case .failure(let error):
                 switch error.code {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -132,7 +132,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Task.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -170,7 +170,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Task.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -211,7 +211,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         let query = Task.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -132,6 +132,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Task.query(kPCKObjectableUUIDKey == uuid)
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
         query.first(callbackQueue: .global(qos: .background)){ result in
             
             switch result {
@@ -162,7 +163,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Task.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             
             switch results {
@@ -202,8 +203,8 @@ public final class Task: PCKVersionable, PCKSynchronizable {
     public func pullRevisions(_ localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
         let query = Task.query(kPCKObjectableClockKey >= localClock)
-        _ = query.order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-        _ = query.includeAll()
+            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKTaskCarePlanKey])
         query.find(callbackQueue: .global(qos: .background)){ results in
             switch results {
             

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -204,7 +204,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     
                     if let customClassName = patient.userInfo?[kPCKCustomClassKey] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, overwriteRemote: overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -219,6 +223,10 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         
                         parse.pushRevision(overwriteRemote, cloudClock: cloudVectorClock){
                             error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -229,7 +237,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 case .carePlan(let carePlan):
                     if let customClassName = carePlan.userInfo?[kPCKCustomClassKey] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, overwriteRemote: overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -243,7 +255,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                         
                         parse.pushRevision(overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -253,7 +269,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 case .contact(let contact):
                     if let customClassName = contact.userInfo?[kPCKCustomClassKey] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, overwriteRemote: overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -265,7 +285,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                             return
                         }
                         parse.pushRevision(overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
     
@@ -276,7 +300,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 case .task(let task):
                     if let customClassName = task.userInfo?[kPCKCustomClassKey] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, overwriteRemote: overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -289,7 +317,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                         
                         parse.pushRevision(overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 
@@ -302,7 +334,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     
                     if let customClassName = outcome.userInfo?[kPCKCustomClassKey] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, overwriteRemote: overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
@@ -314,7 +350,11 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                             return
                         }
                         parse.pushRevision(overwriteRemote, cloudClock: cloudVectorClock){
-                            _ in
+                            error in
+                            
+                            if error != nil {
+                                completion(error)
+                            }
                             revisionsCompletedCount += 1
                             if revisionsCompletedCount == deviceRevision.entities.count{
                                 

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -124,7 +124,7 @@ extension PCKObjectable {
         }
              
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .include([kPCKObjectableNotesKey])
+            .includeAll()
         query.first(callbackQueue: .global(qos: .background)) { result in
             
             switch result {
@@ -149,7 +149,7 @@ extension PCKObjectable {
         }
             
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .include([kPCKObjectableNotesKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)){
             results in
             

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -124,7 +124,7 @@ extension PCKObjectable {
         }
              
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey])
         query.first(callbackQueue: .global(qos: .background)) { result in
             
             switch result {
@@ -149,7 +149,7 @@ extension PCKObjectable {
         }
             
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-        _ = query.includeAll()
+            .include([kPCKObjectableNotesKey])
         query.find(callbackQueue: .global(qos: .background)){
             results in
             

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -248,14 +248,14 @@ extension PCKVersionable {
         let query = queryToAndWith
             .where(doesNotExist(key: kPCKObjectableDeletedDateKey)) //Only consider non deleted keys
             .where(kPCKVersionedObjectEffectiveDateKey < interval.end)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
+            .includeAll()
         return query
     }
     
     private static func queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for date: Date)-> Query<Self> {
         
         let query = Self.query(doesNotExist(key: kPCKVersionedObjectNextKey))
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
+            .includeAll()
         let interval = createCurrentDateInterval(for: date)
         let greaterEqualEffectiveDate = self.query(kPCKVersionedObjectEffectiveDateKey >= interval.end)
         return Self.query(or(queries: [query,greaterEqualEffectiveDate]))
@@ -276,7 +276,7 @@ extension PCKVersionable {
 
     public func find(for date: Date, completion: @escaping([Self]?, ParseError?) -> Void) {
         let query = Self.query(for: date)
-            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
+            .includeAll()
         query.find(callbackQueue: .global(qos: .background)) { results in
             switch results {
             

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -246,15 +246,16 @@ extension PCKVersionable {
         let interval = createCurrentDateInterval(for: date)
     
         let query = queryToAndWith
-        _ = query.where(doesNotExist(key: kPCKObjectableDeletedDateKey)) //Only consider non deleted keys
-        _ = query.where(kPCKVersionedObjectEffectiveDateKey < interval.end)
+            .where(doesNotExist(key: kPCKObjectableDeletedDateKey)) //Only consider non deleted keys
+            .where(kPCKVersionedObjectEffectiveDateKey < interval.end)
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
         return query
     }
     
     private static func queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for date: Date)-> Query<Self> {
         
         let query = Self.query(doesNotExist(key: kPCKVersionedObjectNextKey))
-        
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
         let interval = createCurrentDateInterval(for: date)
         let greaterEqualEffectiveDate = self.query(kPCKVersionedObjectEffectiveDateKey >= interval.end)
         return Self.query(or(queries: [query,greaterEqualEffectiveDate]))
@@ -269,12 +270,13 @@ extension PCKVersionable {
     //This query doesn't filter nextVersion effectiveDate >= interval.end
     public static func query(for date: Date) -> Query<Self> {
         let query = queryVersion(for: date, queryToAndWith: queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for: date))
-        _ = query.includeAll()
+            .includeAll()
         return query
     }
 
     public func find(for date: Date, completion: @escaping([Self]?, ParseError?) -> Void) {
         let query = Self.query(for: date)
+            .include([kPCKObjectableNotesKey, kPCKVersionedObjectPreviousKey, kPCKVersionedObjectNextKey])
         query.find(callbackQueue: .global(qos: .background)) { results in
             switch results {
             


### PR DESCRIPTION
Fixed a bug where if data was in the cloud that contained an array pointer (i.e. Outcomes) and includeAll wasn't used during a fetch, it would throw a decoding error

For now, all entities should always use includeAll when fetching because Parse-Swift won't decode Pointers to ParseObjects.

Also fixed a bug where pushRevisions kept syncing even though an error occurred 