### PR TITLE
Allow copyCareKit to work without being signed in

### DIFF
--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -276,8 +276,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     
     public class func copyCareKit(_ carePlanAny: OCKAnyCarePlan) throws -> CarePlan {
         
-        guard let _ = PCKUser.current,
-            let carePlan = carePlanAny as? OCKCarePlan else{
+        guard let carePlan = carePlanAny as? OCKCarePlan else{
             throw ParseCareKitError.cantCastToNeededClassType
         }
         let encoded = try ParseCareKitUtility.encoder().encode(carePlan)

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -294,8 +294,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
 
     public class func copyCareKit(_ contactAny: OCKAnyContact) throws -> Contact {
         
-        guard let _ = PCKUser.current,
-            let contact = contactAny as? OCKContact else{
+        guard let contact = contactAny as? OCKContact else{
             throw ParseCareKitError.cantCastToNeededClassType
         }
         let encoded = try ParseCareKitUtility.encoder().encode(contact)

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -275,8 +275,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
     open class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Outcome {
         
-        guard let _ = PCKUser.current,
-            let outcome = outcomeAny as? OCKOutcome else{
+        guard let outcome = outcomeAny as? OCKOutcome else{
             throw ParseCareKitError.cantCastToNeededClassType
         }
         

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -281,8 +281,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     
     public class func copyCareKit(_ patientAny: OCKAnyPatient) throws -> Patient {
         
-        guard let _ = PCKUser.current,
-            let patient = patientAny as? OCKPatient else{
+        guard let patient = patientAny as? OCKPatient else{
             throw ParseCareKitError.cantCastToNeededClassType
         }
         

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -282,8 +282,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
     
     public class func copyCareKit(_ taskAny: OCKAnyTask) throws -> Task {
         
-        guard let _ = PCKUser.current,
-            let task = taskAny as? OCKTask else{
+        guard let task = taskAny as? OCKTask else{
             throw ParseCareKitError.cantCastToNeededClassType
         }
         


### PR DESCRIPTION
This allows the OCKStore remote to be set without being logged in. User still won't be able to sync without login