### PR TITLE
Fix nestedUnkeyedContainer when encoding and patch Pointer for Outcomes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "609e879c94b66d1f9909fa4a6ef9bdd70cd550a2",
+          "revision": "34416d781d64091499b6204d2e29aa58d170f137",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,10 +21,10 @@
       },
       {
         "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
+        "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "49177af077c7666156ca5759b9f0176241b001c1",
+          "revision": "609e879c94b66d1f9909fa4a6ef9bdd70cd550a2",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "34416d781d64091499b6204d2e29aa58d170f137",
+          "revision": "a060bf5e2253527a06971da7ccf1127462e057c1",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
-          "branch": "main",
-          "revision": "7015af270a3b1d581b9b01dbf8ea96e3a0c85ec4",
+          "branch": "fixNestedUnkeyedController",
+          "revision": "49177af077c7666156ca5759b9f0176241b001c1",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/carekit-apple/CareKit.git", .branch("main")),
-        .package(url: "https://github.com/parse-community/Parse-Swift.git", .branch("fixNestedUnkeyedController")),
+        .package(url: "https://github.com/netreconlab/Parse-Swift.git", .branch("fixNestedUnkeyedController")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/carekit-apple/CareKit.git", .branch("main")),
-        .package(url: "https://github.com/parse-community/Parse-Swift.git", .branch("main")),
+        .package(url: "https://github.com/parse-community/Parse-Swift.git", .branch("fixNestedUnkeyedController")),
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		709752FA250D351B0020EA70 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		709752FB250D351B0020EA70 /* ParseCareKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
+		70BDECB5255B3BB90083F885 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70BDECB4255B3BB90083F885 /* ParseSwift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		70F2E182254EFC8000B2EA5C /* Patient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FB24561A28001B7AA3 /* Patient.swift */; };
 		70F2E183254EFC8000B2EA5C /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5F824561A28001B7AA3 /* Contact.swift */; };
@@ -156,6 +157,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70BDECB5255B3BB90083F885 /* ParseSwift in Frameworks */,
 				70F2E194254EFCBA00B2EA5C /* CareKitStore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -407,6 +409,7 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70F2E193254EFCBA00B2EA5C /* CareKitStore */,
+				70BDECB4255B3BB90083F885 /* ParseSwift */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -1002,6 +1005,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 70552828252ECA0900336DA1 /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
+		};
+		70BDECB4255B3BB90083F885 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 703E4B72255A3DA400B5C6F6 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
 		};
 		70F2E193254EFCBA00B2EA5C /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -989,7 +989,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
-				branch = main;
+				branch = fixNestedUnkeyedController;
 				kind = branch;
 			};
 		};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
+		703E4B74255A3DA400B5C6F6 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 703E4B73255A3DA400B5C6F6 /* ParseSwift */; };
 		7055282A252ECA0900336DA1 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70552829252ECA0900336DA1 /* CareKitStore */; };
-		7055282E252ECA5500336DA1 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7055282D252ECA5500336DA1 /* ParseSwift */; };
 		705DC9222526A4B80035BBE3 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
@@ -39,7 +39,6 @@
 		70F2E18E254EFC8000B2EA5C /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FD24561A28001B7AA3 /* Note.swift */; };
 		70F2E18F254EFC8000B2EA5C /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FA24561A28001B7AA3 /* Task.swift */; };
 		70F2E194254EFCBA00B2EA5C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70F2E193254EFCBA00B2EA5C /* CareKitStore */; };
-		70F2E2FC254F4E3E00B2EA5C /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70F2E2FB254F4E3E00B2EA5C /* ParseSwift */; };
 		70F2E303254F4F3300B2EA5C /* ParseCareKit_watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 70F2E179254EFC6100B2EA5C /* ParseCareKit_watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9119D5F0245618D7001B7AA3 /* ParseCareKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9119D5EE245618D7001B7AA3 /* ParseCareKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9119D60124561A28001B7AA3 /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5F824561A28001B7AA3 /* Contact.swift */; };
@@ -157,7 +156,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70F2E2FC254F4E3E00B2EA5C /* ParseSwift in Frameworks */,
 				70F2E194254EFCBA00B2EA5C /* CareKitStore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -166,7 +164,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7055282E252ECA5500336DA1 /* ParseSwift in Frameworks */,
+				703E4B74255A3DA400B5C6F6 /* ParseSwift in Frameworks */,
 				7055282A252ECA0900336DA1 /* CareKitStore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -409,7 +407,6 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70F2E193254EFCBA00B2EA5C /* CareKitStore */,
-				70F2E2FB254F4E3E00B2EA5C /* ParseSwift */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -432,7 +429,7 @@
 			name = ParseCareKit;
 			packageProductDependencies = (
 				70552829252ECA0900336DA1 /* CareKitStore */,
-				7055282D252ECA5500336DA1 /* ParseSwift */,
+				703E4B73255A3DA400B5C6F6 /* ParseSwift */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -474,7 +471,7 @@
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
 				70552828252ECA0900336DA1 /* XCRemoteSwiftPackageReference "CareKit" */,
-				7055282C252ECA5500336DA1 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
+				703E4B72255A3DA400B5C6F6 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -977,6 +974,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		703E4B72255A3DA400B5C6F6 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/netreconlab/Parse-Swift.git";
+			requirement = {
+				branch = fixNestedUnkeyedController;
+				kind = branch;
+			};
+		};
 		70552828252ECA0900336DA1 /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
@@ -985,36 +990,23 @@
 				kind = branch;
 			};
 		};
-		7055282C252ECA5500336DA1 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
-			requirement = {
-				branch = fixNestedUnkeyedController;
-				kind = branch;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		703E4B73255A3DA400B5C6F6 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 703E4B72255A3DA400B5C6F6 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
+		};
 		70552829252ECA0900336DA1 /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70552828252ECA0900336DA1 /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
 		};
-		7055282D252ECA5500336DA1 /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7055282C252ECA5500336DA1 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
-		};
 		70F2E193254EFCBA00B2EA5C /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70552828252ECA0900336DA1 /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
-		};
-		70F2E2FB254F4E3E00B2EA5C /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7055282C252ECA5500336DA1 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "609e879c94b66d1f9909fa4a6ef9bdd70cd550a2",
+          "revision": "34416d781d64091499b6204d2e29aa58d170f137",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,10 +21,10 @@
       },
       {
         "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
+        "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "49177af077c7666156ca5759b9f0176241b001c1",
+          "revision": "609e879c94b66d1f9909fa4a6ef9bdd70cd550a2",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/netreconlab/Parse-Swift.git",
         "state": {
           "branch": "fixNestedUnkeyedController",
-          "revision": "34416d781d64091499b6204d2e29aa58d170f137",
+          "revision": "a060bf5e2253527a06971da7ccf1127462e057c1",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
-          "branch": "main",
-          "revision": "7015af270a3b1d581b9b01dbf8ea96e3a0c85ec4",
+          "branch": "fixNestedUnkeyedController",
+          "revision": "49177af077c7666156ca5759b9f0176241b001c1",
           "version": null
         }
       }

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -297,7 +297,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     //Note that CarePlans have to be saved to CareKit first in order to properly convert to CareKit
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKCarePlan {
         self.encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKCarePlan.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -128,7 +128,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         }
         
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKCarePlanPatientKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){
             result in
             
@@ -167,7 +167,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousCarePlanUUID]))
-            .includeAll()
+            .include([kPCKCarePlanPatientKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main) {
             results in
             
@@ -210,7 +210,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKCarePlanPatientKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -28,7 +28,7 @@ public final class CarePlan: PCKVersionable, PCKSynchronizable {
     
     public internal(set) var deletedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -337,7 +337,7 @@ extension CarePlan {
         if encodingForParse {
             try container.encodeIfPresent(patient, forKey: .patient)
         }
-        try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(patientUUID, forKey: .patientUUID)
         try encodeVersionable(to: encoder)
         encodingForParse = true

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -12,7 +12,7 @@ import CareKitStore
 
 
 public final class CarePlan: PCKVersionable, PCKSynchronizable {
-    public var effectiveDate: Date
+    public var effectiveDate: Date?
     
     public internal(set) var uuid: UUID?
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -56,7 +56,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
     
     public internal(set) var deletedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -361,7 +361,7 @@ extension Contact {
         try container.encodeIfPresent(carePlanUUID, forKey: .carePlanUUID)
         try container.encodeIfPresent(address, forKey: .address)
         try container.encodeIfPresent(category, forKey: .category)
-        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(organization, forKey: .organization)
         try container.encodeIfPresent(role, forKey: .role)
         try container.encodeIfPresent(emailAddresses, forKey: .emailAddresses)

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -315,7 +315,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKContact {
         self.encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -40,7 +40,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         }
     }
     
-    public var effectiveDate: Date
+    public var effectiveDate: Date?
     
     public internal(set) var uuid: UUID?
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -144,7 +144,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Contact.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKContactCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -181,7 +181,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Contact.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
-            .includeAll()
+            .include([kPCKContactCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -222,7 +222,7 @@ public final class Contact: PCKVersionable, PCKSynchronizable {
         
         let query = Contact.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKContactCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -24,7 +24,7 @@ open class Note: PCKObjectable {
     
     public internal(set) var updatedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -90,7 +90,7 @@ open class Note: PCKObjectable {
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
     open func convertToCareKit(fromCloud:Bool=true) throws -> OCKNote {
         encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKNote.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -135,7 +135,7 @@ open class Note: PCKObjectable {
             return
         }
         let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: uuids))
-            .includeAll()
+            .include([kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,7 +105,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -127,7 +127,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                         return
                     }
                     let query = Outcome.query(kPCKObjectableEntityIdKey == self.id, doesNotExist(key: kPCKObjectableDeletedDateKey))
-                        .includeAll()
+                        .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
                     query.first(callbackQueue: .main){ result in
                         
                         switch result {
@@ -166,7 +166,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             switch results {
             
@@ -227,7 +227,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                 
         //Get latest item from the Cloud to compare against
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -405,7 +405,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         let taskQuery = Task.query(doesNotExist(key: kPCKObjectableDeletedDateKey))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
         let query = Outcome.query(doesNotExist(key: kPCKObjectableDeletedDateKey), matchesKeyInQuery(key: kPCKOutcomeTaskKey, queryKey: kPCKOutcomeTaskKey, query: taskQuery))
-            .includeAll()
+            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         return query
     }
    

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -78,16 +78,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         case uuid, entityId, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
-    /*
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        
-        objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
-        values = try container.decodeIfPresent([OutcomeValue].self, forKey: .values)
-        task = try container.decodeIfPresent(Task.self, forKey: .task)
-        print("here")
-    }
-    */
+
     public func new(with careKitEntity: OCKEntity) throws -> PCKSynchronizable {
         
         switch careKitEntity {
@@ -321,7 +312,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcome {
         self.encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcome.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -78,7 +78,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         case uuid, entityId, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
-    
+    /*
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -87,7 +87,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         task = try container.decodeIfPresent(Task.self, forKey: .task)
         print("here")
     }
-    
+    */
     public func new(with careKitEntity: OCKEntity) throws -> PCKSynchronizable {
         
         switch careKitEntity {

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -440,14 +440,13 @@ extension Outcome {
         }
         try container.encodeIfPresent(taskUUID, forKey: .taskUUID)
         try container.encodeIfPresent(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
-        try container.encodeIfPresent(values, forKey: .values)
-        /*guard let valuesToEncode = values else {
+        guard let valuesToEncode = values else {
             throw ParseCareKitError.requiredValueCantBeUnwrapped
         }
         try valuesToEncode.forEach { value in
             var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .values)
             try nestedUnkeyedContainer.encode(value)
-        }*/
+        }
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         if id.count > 0 {
             entityId = id

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -166,7 +166,8 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .includeAll()
+            //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -440,14 +440,14 @@ extension Outcome {
         }
         try container.encodeIfPresent(taskUUID, forKey: .taskUUID)
         try container.encodeIfPresent(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
-        //try container.encodeIfPresent(values., forKey: .values)
-        guard let valuesToEncode = values else {
+        try container.encodeIfPresent(values, forKey: .values)
+        /*guard let valuesToEncode = values else {
             throw ParseCareKitError.requiredValueCantBeUnwrapped
         }
         try valuesToEncode.forEach { value in
             var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .values)
             try nestedUnkeyedContainer.encode(value)
-        }
+        }*/
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         if id.count > 0 {
             entityId = id

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -11,7 +11,7 @@ import ParseSwift
 import CareKitStore
 
 
-public class Outcome: PCKObjectable, PCKSynchronizable {
+final public class Outcome: PCKObjectable, PCKSynchronizable {
     
     public internal(set) var uuid: UUID?
 
@@ -79,6 +79,15 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
     
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
+        values = try container.decodeIfPresent([OutcomeValue].self, forKey: .values)
+        task = try container.decodeIfPresent(Task.self, forKey: .values)
+        print("here")
+    }
+    
     public func new(with careKitEntity: OCKEntity) throws -> PCKSynchronizable {
         
         switch careKitEntity {
@@ -90,7 +99,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         }
     }
     
-    open func addToCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
+    public func addToCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
             
         guard let _ = PCKUser.current,
               let uuid = self.uuid else{
@@ -152,12 +161,12 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         }
     }
     
-    open func updateCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
+    public func updateCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         //Handled with tombstone, marked for deletion
         completion(false,ParseCareKitError.requiredValueCantBeUnwrapped)
     }
     
-    open func deleteFromCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
+    public func deleteFromCloud(_ usingClock:Bool=false, overwriteRemote: Bool=false, completion: @escaping(Bool,Error?) -> Void){
         //Handled with update, marked for deletion
         completion(true,nil)
     }
@@ -275,7 +284,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         return copied
     }
         
-    open class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Outcome {
+    public class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Outcome {
         
         guard let outcome = outcomeAny as? OCKOutcome else{
             throw ParseCareKitError.cantCastToNeededClassType
@@ -310,7 +319,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
     }
 
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
-    open func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcome {
+    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcome {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.encoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcome.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,7 +105,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .include([kPCKOutcomeValuesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -127,7 +127,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                         return
                     }
                     let query = Outcome.query(kPCKObjectableEntityIdKey == self.id, doesNotExist(key: kPCKObjectableDeletedDateKey))
-                        .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+                        .include([kPCKOutcomeValuesKey])
                     query.first(callbackQueue: .main){ result in
                         
                         switch result {
@@ -166,7 +166,8 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKOutcomeValuesKey])
+            //.includeAll()
             //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             switch results {
@@ -228,7 +229,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
                 
         //Get latest item from the Cloud to compare against
         let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .include([kPCKOutcomeValuesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -406,7 +407,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         let taskQuery = Task.query(doesNotExist(key: kPCKObjectableDeletedDateKey))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
         let query = Outcome.query(doesNotExist(key: kPCKObjectableDeletedDateKey), matchesKeyInQuery(key: kPCKOutcomeTaskKey, queryKey: kPCKOutcomeTaskKey, query: taskQuery))
-            .include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
+            .include([kPCKOutcomeValuesKey])
         return query
     }
    

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -166,7 +166,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKOutcomeValuesKey])
+            .include([kPCKOutcomeTaskKey, kPCKOutcomeValuesKey])
             //.includeAll()
             //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -27,7 +27,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
     
     public internal(set) var deletedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -166,7 +166,7 @@ public class Outcome: PCKObjectable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKOutcomeTaskKey, kPCKOutcomeValuesKey])
+            .include([kPCKOutcomeValuesKey])
             //.includeAll()
             //.include([kPCKOutcomeValuesKey, kPCKOutcomeTaskKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
@@ -438,9 +438,9 @@ extension Outcome {
             try container.encodeIfPresent(task, forKey: .task)
             try container.encodeIfPresent(date, forKey: .date)
         }
-        try container.encode(taskUUID, forKey: .taskUUID)
-        try container.encode(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
-        //try container.encode(values., forKey: .values)
+        try container.encodeIfPresent(taskUUID, forKey: .taskUUID)
+        try container.encodeIfPresent(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
+        //try container.encodeIfPresent(values., forKey: .values)
         guard let valuesToEncode = values else {
             throw ParseCareKitError.requiredValueCantBeUnwrapped
         }

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -84,7 +84,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         
         objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
         values = try container.decodeIfPresent([OutcomeValue].self, forKey: .values)
-        task = try container.decodeIfPresent(Task.self, forKey: .values)
+        task = try container.decodeIfPresent(Task.self, forKey: .task)
         print("here")
     }
     

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -179,7 +179,7 @@ final public class OutcomeValue: PCKObjectable {
     
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcomeValue {
         encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcomeValue.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -25,7 +25,7 @@ final public class OutcomeValue: PCKObjectable {
     
     public internal(set) var updatedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -96,7 +96,15 @@ final public class OutcomeValue: PCKObjectable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let valueType = try container.decode(OCKOutcomeValueType.self, forKey: .type)
+        
+        //Decode Parse first
+        objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+        
+        guard let valueType = try container.decodeIfPresent(OCKOutcomeValueType.self, forKey: .type) else {
+            return
+        }
 
         if let valueDictionary = try? container.decodeIfPresent([String: AnyCodable].self, forKey: .value) {
             if let tempValue = valueDictionary[valueType.rawValue]?.value as? Int {
@@ -130,9 +138,7 @@ final public class OutcomeValue: PCKObjectable {
                 value = try container.decode(Date.self, forKey: .value)
             }
         }
-        objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
-        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
-        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+        
         kind = try container.decodeIfPresent(String.self, forKey: .kind)
         units = try container.decodeIfPresent(String.self, forKey: .units)
         index = try container.decodeIfPresent(Int.self, forKey: .index)
@@ -145,7 +151,7 @@ final public class OutcomeValue: PCKObjectable {
         remoteID = try container.decodeIfPresent(String.self, forKey: .remoteID)
         source = try container.decodeIfPresent(String.self, forKey: .source)
         userInfo = try container.decodeIfPresent([String: String].self, forKey: .userInfo)
-        timezone = try container.decode(TimeZone.self, forKey: .timezone)
+        timezone = try container.decodeIfPresent(TimeZone.self, forKey: .timezone)
         asset = try container.decodeIfPresent(String.self, forKey: .asset)
         notes = try container.decodeIfPresent([Note].self, forKey: .notes)
         logicalClock = try container.decodeIfPresent(Int.self, forKey: .logicalClock)
@@ -210,12 +216,12 @@ extension OutcomeValue {
         try container.encodeIfPresent(index, forKey: .index)
         if encodingForParse {
             var encodedValue = false
-            if let value = integerValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true } else
-            if let value = doubleValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true } else
-            if let value = stringValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true } else
-            if let value = booleanValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true } else
-            if let value = dataValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true } else
-            if let value = dateValue { try container.encode([type.rawValue: value], forKey: .value); encodedValue = true }
+            if let value = integerValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true } else
+            if let value = doubleValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true } else
+            if let value = stringValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true } else
+            if let value = booleanValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true } else
+            if let value = dataValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true } else
+            if let value = dateValue { try container.encodeIfPresent([type.rawValue: value], forKey: .value); encodedValue = true }
 
             guard encodedValue else {
                 let message = "Value could not be converted to a concrete type."
@@ -223,12 +229,12 @@ extension OutcomeValue {
             }
         } else {
             var encodedValue = false
-            if let value = integerValue { try container.encode(value, forKey: .value); encodedValue = true } else
-            if let value = doubleValue { try container.encode(value, forKey: .value); encodedValue = true } else
-            if let value = stringValue { try container.encode(value, forKey: .value); encodedValue = true } else
-            if let value = booleanValue { try container.encode(value, forKey: .value); encodedValue = true } else
-            if let value = dataValue { try container.encode(value, forKey: .value); encodedValue = true } else
-            if let value = dateValue { try container.encode(value, forKey: .value); encodedValue = true }
+            if let value = integerValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true } else
+            if let value = doubleValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true } else
+            if let value = stringValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true } else
+            if let value = booleanValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true } else
+            if let value = dataValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true } else
+            if let value = dateValue { try container.encodeIfPresent(value, forKey: .value); encodedValue = true }
 
             guard encodedValue else {
                 let message = "Value could not be converted to a concrete type."

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -40,7 +40,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         }
     }
     
-    public var effectiveDate: Date
+    public var effectiveDate: Date?
     
     public internal(set) var uuid: UUID?
     

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -301,7 +301,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKPatient {
         self.encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKPatient.self, from: encoded)
     }
 }

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -56,7 +56,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
     
     public internal(set) var deletedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -107,7 +107,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(allergies, forKey: .allergies)
         try container.encodeIfPresent(birthday, forKey: .birthday)
-        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(sex, forKey: .sex)
         try encodeVersionable(to: encoder)
         encodingForParse = true

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -133,7 +133,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
 
         //Check to see if already in the cloud
         let query = Self.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){ result in
            
             switch result {
@@ -172,7 +172,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not paired locally
         let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -215,7 +215,7 @@ public final class Patient: PCKVersionable, PCKSynchronizable {
         
         let query = Self.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -57,7 +57,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
     
     public internal(set) var deletedDate: Date?
     
-    public var timezone: TimeZone
+    public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
     
@@ -357,13 +357,13 @@ extension Task {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if encodingForParse {
-            try container.encode(carePlan, forKey: .carePlan)
+            try container.encodeIfPresent(carePlan, forKey: .carePlan)
         }
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(carePlanUUID, forKey: .carePlanUUID)
-        try container.encode(impactsAdherence, forKey: .impactsAdherence)
+        try container.encodeIfPresent(impactsAdherence, forKey: .impactsAdherence)
         try container.encodeIfPresent(instructions, forKey: .instructions)
-        try container.encode(schedule, forKey: .schedule)
+        try container.encodeIfPresent(schedule, forKey: .schedule)
         try encodeVersionable(to: encoder)
         encodingForParse = true
     }

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -41,7 +41,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         }
     }
     
-    public var effectiveDate: Date
+    public var effectiveDate: Date?
     
     public internal(set) var uuid: UUID?
     

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -132,7 +132,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if already in the cloud
         let query = Task.query(kPCKObjectableUUIDKey == uuid)
-            .includeAll()
+            .include([kPCKTaskCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -170,7 +170,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Task.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
-            .includeAll()
+            .include([kPCKTaskCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -211,7 +211,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
         
         let query = Task.query(kPCKObjectableClockKey >= localClock)
             .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .includeAll()
+            .include([kPCKTaskCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             switch results {
             

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -310,7 +310,7 @@ public final class Task: PCKVersionable, PCKSynchronizable {
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
     public func convertToCareKit(fromCloud:Bool=true) throws -> OCKTask {
         self.encodingForParse = false
-        let encoded = try ParseCareKitUtility.encoder().encode(self)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKTask.self, from: encoded)
     }
     

--- a/Sources/ParseCareKit/ParseCareKitUtility.swift
+++ b/Sources/ParseCareKit/ParseCareKitUtility.swift
@@ -56,6 +56,10 @@ public struct ParseCareKitUtility {
         Note().getEncoder()
     }
 
+    public static func jsonEncoder() -> JSONEncoder {
+        Note().getJSONEncoder()
+    }
+    
     public static func decoder() -> JSONDecoder {
         Note().getDecoder()
     }

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -124,7 +124,7 @@ extension PCKObjectable {
         }
              
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .includeAll()
+            .include([kPCKObjectableNotesKey])
         query.first(callbackQueue: .main) { result in
             
             switch result {
@@ -149,7 +149,7 @@ extension PCKObjectable {
         }
             
         let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .includeAll()
+            .include([kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){
             results in
             

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -35,7 +35,7 @@ internal protocol PCKObjectable: ParseObject {
     var updatedDate: Date? {get set}
     
     /// The timezone this record was created in.
-    var timezone: TimeZone {get set}
+    var timezone: TimeZone? {get set}
     
     /// A dictionary of information that can be provided by developers to support their own unique
     /// use cases.
@@ -207,11 +207,11 @@ extension PCKObjectable {
                 try container.encodeIfPresent(entityId, forKey: .id)
             }
         }
-        try container.encode(uuid, forKey: .uuid)
-        try container.encode(schemaVersion, forKey: .schemaVersion)
-        try container.encode(createdDate, forKey: .createdDate)
-        try container.encode(updatedDate, forKey: .updatedDate)
-        try container.encode(timezone, forKey: .timezone)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(schemaVersion, forKey: .schemaVersion)
+        try container.encodeIfPresent(createdDate, forKey: .createdDate)
+        try container.encodeIfPresent(updatedDate, forKey: .updatedDate)
+        try container.encodeIfPresent(timezone, forKey: .timezone)
         try container.encodeIfPresent(userInfo, forKey: .userInfo)
         try container.encodeIfPresent(groupIdentifier, forKey: .groupIdentifier)
         try container.encodeIfPresent(tags, forKey: .tags)

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -22,7 +22,7 @@ internal protocol PCKVersionable: PCKObjectable {
     
     /// The date that this version of the object begins to take precedence over the previous version.
     /// Often this will be the same as the `createdDate`, but is not required to be.
-    var effectiveDate: Date { get set }
+    var effectiveDate: Date? { get set }
 
     /// The date on which this object was marked deleted. Note that objects are never actually deleted,
     /// but rather they are marked deleted and will no longer be returned from queries.

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -248,14 +248,14 @@ extension PCKVersionable {
         let query = queryToAndWith
             .where(doesNotExist(key: kPCKObjectableDeletedDateKey)) //Only consider non deleted keys
             .where(kPCKVersionedObjectEffectiveDateKey < interval.end)
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         return query
     }
     
     private static func queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for date: Date)-> Query<Self> {
         
         let query = Self.query(doesNotExist(key: kPCKVersionedObjectNextKey))
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         let interval = createCurrentDateInterval(for: date)
         let greaterEqualEffectiveDate = self.query(kPCKVersionedObjectEffectiveDateKey >= interval.end)
         return Self.query(or(queries: [query,greaterEqualEffectiveDate]))
@@ -270,13 +270,13 @@ extension PCKVersionable {
     //This query doesn't filter nextVersion effectiveDate >= interval.end
     public static func query(for date: Date) -> Query<Self> {
         let query = queryVersion(for: date, queryToAndWith: queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for: date))
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         return query
     }
 
     public func find(for date: Date, completion: @escaping([Self]?, ParseError?) -> Void) {
         let query = Self.query(for: date)
-            .includeAll()
+            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main) { results in
             switch results {
             

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -304,7 +304,7 @@ extension PCKVersionable {
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         try container.encodeIfPresent(previousVersionUUID, forKey: .previousVersionUUID)
         try container.encodeIfPresent(nextVersionUUID, forKey: .nextVersionUUID)
-        try container.encode(effectiveDate, forKey: .effectiveDate)
+        try container.encodeIfPresent(effectiveDate, forKey: .effectiveDate)
         try encodeObjectable(to: encoder)
     }
 }

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -172,7 +172,8 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.content, "world")
         
         //Encode to cloud format
-        let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
+        let cloudEncoded = try ParseCoding.jsonEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Note.self, from: cloudEncoded)
         
         //Objectable
@@ -293,6 +294,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
         
         //Encode to cloud format
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Patient.self, from: cloudEncoded)
         
@@ -410,7 +412,8 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.content, "world")
         
         //Test Parse -> ParseServer
-        let encoded = try parse.getEncoder().encode(parse)
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
+        let encoded = try parse.getJSONEncoder().encode(parse)
         let decoded = try parse.getDecoder().decode([String: AnyCodable].self, from: encoded)
         if let decodedValue = decoded["value"]?.value as? [String: Int] {
             XCTAssertEqual(decodedValue["integer"], 10)
@@ -560,6 +563,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.content, "world")
         
         //Encode to cloud format
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Outcome.self, from: cloudEncoded)
         
@@ -733,6 +737,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
         
         //Encode to cloud format
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Task.self, from: cloudEncoded)
         
@@ -853,6 +858,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
         
         //Encode to cloud format
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(CarePlan.self, from: cloudEncoded)
         
@@ -999,6 +1005,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
         
         //Encode to cloud format
+        parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Contact.self, from: cloudEncoded)
         


### PR DESCRIPTION
- Adds the patched Parse-Swift to fix nestedUnkeyedContainer (waiting for PR to merge to main)
- Patched a pointer issue that's currently on parse-server where ParseObjects that include both a Pointer and PointerArray can't be pulled using includeAll