### PR TITLE
Fix syncing notes. Add oslog, swiftLint, and public protocols

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,9 @@ coverage:
   ignore:
     - Tests/.*
   status:
-    patch: true
+    patch:
+      default:
+        target: 0
     changes: false
     project:
       default:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CI_XCODE_VER: '/Applications/Xcode_12.app/Contents/Developer'
+  CI_XCODE_VER_11: '/Applications/Xcode_11.7.app/Contents/Developer'
 
 jobs:
   xcode-test-ios:
@@ -16,6 +17,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,name\=iPhone\ 11\ Pro\ Max test | xcpretty
+    - name: Codecov
+      run: bash <(curl https://codecov.io/bash)
+
+  xcode-test-ios-11:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,name\=iPhone\ 11\ Pro\ Max test | xcpretty
+      env: 
+        DEVELOPER_DIR: ${{ env.CI_XCODE_VER_11 }}
     - name: Codecov
       run: bash <(curl https://codecov.io/bash)
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,OS=13.0,name\=iPhone\ 11\ Pro\ Max test | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,OS=13.7,name\=iPhone\ 11\ Pro\ Max test | xcpretty
       env: 
         DEVELOPER_DIR: ${{ env.CI_XCODE_VER_11 }}
     - name: Codecov

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,8 +26,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,OS=13.7,name\=iPhone\ 11\ Pro\ Max test | xcpretty
-      env: 
-        DEVELOPER_DIR: ${{ env.CI_XCODE_VER_11 }}
     - name: Codecov
       run: bash <(curl https://codecov.io/bash)
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,12 +20,12 @@ jobs:
     - name: Codecov
       run: bash <(curl https://codecov.io/bash)
 
-  xcode-test-ios-11:
+  xcode-test-ios-13:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,name\=iPhone\ 11\ Pro\ Max test | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,OS=13.0,name\=iPhone\ 11\ Pro\ Max test | xcpretty
       env: 
         DEVELOPER_DIR: ${{ env.CI_XCODE_VER_11 }}
     - name: Codecov

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,15 +20,6 @@ jobs:
     - name: Codecov
       run: bash <(curl https://codecov.io/bash)
 
-  xcode-test-ios-13:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -testPlan ParseCareKit -scheme ParseCareKit -destination platform\=iOS\ Simulator,OS=13.7,name\=iPhone\ 11\ Pro\ Max test | xcpretty
-    - name: Codecov
-      run: bash <(curl https://codecov.io/bash)
-
   spm-test:
     runs-on: macos-latest
     steps:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - cyclomatic_complexity
+  - function_body_length
+  - type_body_length
+excluded:
+  - .build
+  - DerivedData

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to the ParseCareKit Framework
+
+If you are not familiar with Pull Requests and want to know more about them, you can visit the [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) article. It contains detailed information about the process.
+
+## Setting up your local machine
+
+* [Fork](https://github.com/netreconlab/ParseCareKit.git) this project and clone the fork on to your local machine:
+
+```sh
+$ git clone https://github.com/netreconlab/ParseCareKit.git
+$ cd ParseCareKit # go into the clone directory
+```
+
+* Please install [SwiftLint](https://github.com/realm/SwiftLint) to ensure that your PR conforms to our coding standards:
+
+```sh
+$ brew install swiftlint
+```

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": "fixEncodingArrays",
-          "revision": "7010004e23f49357541204109dab0e79eef56916",
+          "revision": "a42ff246bebc93476338a968bcb6c53414d11a9f",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
-          "branch": "main",
-          "revision": "177f01b41f22c76bf0e9e13b4a399190c7b4c38a",
+          "branch": "fixEncodingArrays",
+          "revision": "7010004e23f49357541204109dab0e79eef56916",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
-          "branch": "fixEncodingArrays",
-          "revision": "a42ff246bebc93476338a968bcb6c53414d11a9f",
+          "branch": "main",
+          "revision": "0e917539289d6f15c86febb4156da2d4eda8360b",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/carekit-apple/CareKit.git", .branch("main")),
-        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("fixEncodingArrays"))
+        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("main"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/carekit-apple/CareKit.git", .branch("main")),
-        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("main")),
+        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("fixEncodingArrays")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,12 @@ let package = Package(
     products: [
         .library(
             name: "ParseCareKit",
-            targets: ["ParseCareKit"]),
+            targets: ["ParseCareKit"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/carekit-apple/CareKit.git", .branch("main")),
-        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("fixEncodingArrays")),
+        .package(url: "https://github.com/parse-community/Parse-Swift", .branch("fixEncodingArrays"))
     ],
     targets: [
         .target(
@@ -22,6 +22,6 @@ let package = Package(
             dependencies: ["ParseSwift", "CareKitStore"]),
         .testTarget(
             name: "ParseCareKitTests",
-            dependencies: ["ParseCareKit"]),
+            dependencies: ["ParseCareKit"])
     ]
 )

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -989,7 +989,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
-				branch = main;
+				branch = fixEncodingArrays;
 				kind = branch;
 			};
 		};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		709752EF250D27320020EA70 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 709752ED250D27320020EA70 /* LaunchScreen.storyboard */; };
 		709752FA250D351B0020EA70 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		709752FB250D351B0020EA70 /* ParseCareKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		709D175D258551D20002E772 /* ParseCareKitLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D175C258551D20002E772 /* ParseCareKitLog.swift */; };
+		709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D175C258551D20002E772 /* ParseCareKitLog.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		70F2E182254EFC8000B2EA5C /* Patient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FB24561A28001B7AA3 /* Patient.swift */; };
@@ -113,6 +115,7 @@
 		7098A7762524E92900DDF53D /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		7098A7772524E92900DDF53D /* MockURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLResponse.swift; sourceTree = "<group>"; };
 		7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingCareKitTests.swift; sourceTree = "<group>"; };
+		709D175C258551D20002E772 /* ParseCareKitLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitLog.swift; sourceTree = "<group>"; };
 		70B326BD251EBE610028B229 /* PCKUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUser.swift; sourceTree = "<group>"; };
 		70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseCareKit_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E179254EFC6100B2EA5C /* ParseCareKit_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseCareKit_watchOS.h; sourceTree = "<group>"; };
@@ -304,6 +307,7 @@
 				91AA07222466F0CD00B39452 /* Clock.swift */,
 				9119D5EE245618D7001B7AA3 /* ParseCareKit.h */,
 				9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */,
+				709D175C258551D20002E772 /* ParseCareKitLog.swift */,
 				9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */,
 				916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */,
 			);
@@ -548,6 +552,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */,
 				70F2E187254EFC8000B2EA5C /* ParseCareKitConstants.swift in Sources */,
 				70F2E189254EFC8000B2EA5C /* ParseRemoteSynchronizationManager.swift in Sources */,
 				70F2E183254EFC8000B2EA5C /* Contact.swift in Sources */,
@@ -570,6 +575,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				709D175D258551D20002E772 /* ParseCareKitLog.swift in Sources */,
 				9119D60B24561B02001B7AA3 /* ParseCareKitConstants.swift in Sources */,
 				9119D60D24561B22001B7AA3 /* ParseCareKitUtility.swift in Sources */,
 				700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */,

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		709752FB250D351B0020EA70 /* ParseCareKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		709D175D258551D20002E772 /* ParseCareKitLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D175C258551D20002E772 /* ParseCareKitLog.swift */; };
 		709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D175C258551D20002E772 /* ParseCareKitLog.swift */; };
+		709D176B258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
+		709D176C258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		70F2E182254EFC8000B2EA5C /* Patient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FB24561A28001B7AA3 /* Patient.swift */; };
@@ -116,6 +118,7 @@
 		7098A7772524E92900DDF53D /* MockURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLResponse.swift; sourceTree = "<group>"; };
 		7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingCareKitTests.swift; sourceTree = "<group>"; };
 		709D175C258551D20002E772 /* ParseCareKitLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitLog.swift; sourceTree = "<group>"; };
+		709D176A258579090002E772 /* ParseCareKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitError.swift; sourceTree = "<group>"; };
 		70B326BD251EBE610028B229 /* PCKUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUser.swift; sourceTree = "<group>"; };
 		70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseCareKit_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E179254EFC6100B2EA5C /* ParseCareKit_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseCareKit_watchOS.h; sourceTree = "<group>"; };
@@ -304,9 +307,9 @@
 				918F080B248040AA00C3A205 /* Objects */,
 				703CDA0725243D230027AB82 /* Parse */,
 				91D52878248128700022292B /* Protocols */,
-				91AA07222466F0CD00B39452 /* Clock.swift */,
 				9119D5EE245618D7001B7AA3 /* ParseCareKit.h */,
 				9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */,
+				709D176A258579090002E772 /* ParseCareKitError.swift */,
 				709D175C258551D20002E772 /* ParseCareKitLog.swift */,
 				9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */,
 				916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */,
@@ -318,6 +321,7 @@
 			isa = PBXGroup;
 			children = (
 				9119D5FE24561A28001B7AA3 /* CarePlan.swift */,
+				91AA07222466F0CD00B39452 /* Clock.swift */,
 				9119D5F824561A28001B7AA3 /* Contact.swift */,
 				9119D5FD24561A28001B7AA3 /* Note.swift */,
 				9119D5FF24561A28001B7AA3 /* Outcome.swift */,
@@ -558,6 +562,7 @@
 				70F2E183254EFC8000B2EA5C /* Contact.swift in Sources */,
 				70F2E184254EFC8000B2EA5C /* PCKUser.swift in Sources */,
 				70F2E186254EFC8000B2EA5C /* Outcome.swift in Sources */,
+				709D176C258579090002E772 /* ParseCareKitError.swift in Sources */,
 				70F2E18D254EFC8000B2EA5C /* Clock.swift in Sources */,
 				70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */,
 				70F2E18F254EFC8000B2EA5C /* Task.swift in Sources */,
@@ -581,6 +586,7 @@
 				700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */,
 				9119D60324561A28001B7AA3 /* Task.swift in Sources */,
 				9119D60824561A28001B7AA3 /* Outcome.swift in Sources */,
+				709D176B258579090002E772 /* ParseCareKitError.swift in Sources */,
 				70B326BE251EBE610028B229 /* PCKUser.swift in Sources */,
 				9119D60624561A28001B7AA3 /* Note.swift in Sources */,
 				918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */,

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D175C258551D20002E772 /* ParseCareKitLog.swift */; };
 		709D176B258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
 		709D176C258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
+		709D18072586903C0002E772 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D18062586903C0002E772 /* LoggerTests.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		70F2E182254EFC8000B2EA5C /* Patient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FB24561A28001B7AA3 /* Patient.swift */; };
@@ -119,6 +120,7 @@
 		7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingCareKitTests.swift; sourceTree = "<group>"; };
 		709D175C258551D20002E772 /* ParseCareKitLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitLog.swift; sourceTree = "<group>"; };
 		709D176A258579090002E772 /* ParseCareKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitError.swift; sourceTree = "<group>"; };
+		709D18062586903C0002E772 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		70B326BD251EBE610028B229 /* PCKUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUser.swift; sourceTree = "<group>"; };
 		70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseCareKit_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F2E179254EFC6100B2EA5C /* ParseCareKit_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseCareKit_watchOS.h; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */,
+				709D18062586903C0002E772 /* LoggerTests.swift */,
 				7098A7752524E92900DDF53D /* NetworkMocking */,
 			);
 			path = ParseCareKitTests;
@@ -560,6 +563,7 @@
 				705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */,
 				705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */,
 				705DC92D2526A5650035BBE3 /* MockURLResponse.swift in Sources */,
+				709D18072586903C0002E772 /* LoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 				9119D5E8245618D7001B7AA3 /* Frameworks */,
 				9119D5E9245618D7001B7AA3 /* Resources */,
 				9119D62124562933001B7AA3 /* Embed Frameworks */,
+				709D177F258580620002E772 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -530,6 +531,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		709D177F258580620002E772 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n  swiftlint autocorrect && swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		705DC9192526A4B80035BBE3 /* Sources */ = {

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1022,7 +1022,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
-				branch = fixEncodingArrays;
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
-          "branch": "main",
-          "revision": "177f01b41f22c76bf0e9e13b4a399190c7b4c38a",
+          "branch": "fixEncodingArrays",
+          "revision": "a42ff246bebc93476338a968bcb6c53414d11a9f",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
-          "branch": "fixEncodingArrays",
-          "revision": "a42ff246bebc93476338a968bcb6c53414d11a9f",
+          "branch": "main",
+          "revision": "0e917539289d6f15c86febb4156da2d4eda8360b",
           "version": null
         }
       }

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ class CancerPatient: Patient {
         self.comorbidities = cancerPatient.userInfo?["CustomPatientUserInfoComorbiditiesKey"]
     }
     
-    override func convertToCareKit(fromCloud: Bool=false) -> OCKPatient? {
-        guard var partiallyConvertedPatient = super.convertToCareKit(fromCloud: fromCloud) else{return nil}
+    override func convertToCareKit() -> OCKPatient? {
+        guard var partiallyConvertedPatient = super.convertToCareKit() else{return nil}
         
         var userInfo: [String:String]!
         if partiallyConvertedPatient.userInfo == nil{
@@ -262,8 +262,8 @@ class Doctor: Patient {
         return seld
     }
     
-    override func convertToCareKit(fromCloud: Bool=false) -> OCKPatient? {
-        guard var partiallyConvertedDoctor = super.convertToCareKit(fromCloud: fromCloud) else{return nil}
+    override func convertToCareKit() -> OCKPatient? {
+        guard var partiallyConvertedDoctor = super.convertToCareKit() else{return nil}
         
         var userInfo: [String:String]!
         if partiallyConvertedDoctor.userInfo == nil{
@@ -301,7 +301,7 @@ _ = Doctor(careKitEntity: newCareKitDoctor){
    newParseDoctor.sex = "Female" //This default from OCKPatient, Doctor has all defaults of it's CareKit counterpart
    
    
-   guard let updatedCareKitDoctor = newParseDoctor.convertToCareKit(fromCloud: false) else {
+   guard let updatedCareKitDoctor = newParseDoctor.convertToCareKit() else {
        completion(nil,nil)
        return
    }

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ class Doctor: Patient {
         case .patient(let entity):
             return Doctor(careKitEntity: entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ class Doctor: Patient {
             return Doctor(careKitEntity: entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
             }
             completion(nil)
         }

--- a/README.md
+++ b/README.md
@@ -235,7 +235,11 @@ class Doctor: Patient {
         case .patient(let entity):
             return Doctor(careKitEntity: entity)
         default:
-            print("Error in \(className).new(with:). The wrong type of entity was passed \(careKitEntity)")
+            if #available(iOS 14.0, *) {
+                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+            } else {
+                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
+            }
             completion(nil)
         }
     }

--- a/Sources/ParseCareKit/Clock.swift
+++ b/Sources/ParseCareKit/Clock.swift
@@ -48,9 +48,9 @@ struct Clock: ParseObject {
             cloudVector = try JSONDecoder().decode(OCKRevisionRecord.KnowledgeVector.self, from: data)
         } catch {
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.clock.error("Clock.decodeClock(): \(error.localizedDescription). Vector \(data).")
+                Logger.clock.error("Clock.decodeClock(): \(error.localizedDescription, privacy: .private). Vector \(data, privacy: .private).")
             } else {
-                os_log("Clock.decodeClock(): %{public}@. Vector %{public}@.", log: .clock, type: .error, error.localizedDescription, data.description)
+                os_log("Clock.decodeClock(): %{private}@. Vector %{private}@.", log: .clock, type: .error, error.localizedDescription, data.description)
             }
             cloudVector = nil
         }
@@ -65,9 +65,9 @@ struct Clock: ParseObject {
             return self.vector
         } catch {
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.clock.error("Clock.encodeClock(): \(error.localizedDescription).")
+                Logger.clock.error("Clock.encodeClock(): \(error.localizedDescription, privacy: .private).")
             } else {
-                os_log("Clock.decodeClock(): %{public}@.", log: .clock, type: .error, error.localizedDescription)
+                os_log("Clock.decodeClock(): %{private}@.", log: .clock, type: .error, error.localizedDescription)
             }
             return nil
         }

--- a/Sources/ParseCareKit/Clock.swift
+++ b/Sources/ParseCareKit/Clock.swift
@@ -25,7 +25,7 @@ struct Clock: ParseObject {
     var vector:String?
 
     public var localizedDescription: String {
-        "\(debugDescription) vector: \(String(describing: vector))"
+        "\(debugDescription) vector=\(String(describing: vector))"
     }
 
     init(uuid: UUID) {
@@ -50,7 +50,7 @@ struct Clock: ParseObject {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.clock.error("Clock.decodeClock(): \(error.localizedDescription, privacy: .private). Vector \(data, privacy: .private).")
             } else {
-                os_log("Clock.decodeClock(): %{private}@. Vector %{private}@.", log: .clock, type: .error, error.localizedDescription, data.description)
+                os_log("Clock.decodeClock(): %{private}@. Vector %{private}@.", log: .clock, type: .error, error.localizedDescription, data.debugDescription)
             }
             cloudVector = nil
         }

--- a/Sources/ParseCareKit/Clock.swift
+++ b/Sources/ParseCareKit/Clock.swift
@@ -35,7 +35,7 @@ struct Clock: ParseObject {
     
     func decodeClock(completion:@escaping(OCKRevisionRecord.KnowledgeVector?)->Void){
         guard let data = self.vector?.data(using: .utf8) else {
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.clock.error("Error in Clock. Couldn't get data as utf8")
             } else {
                 os_log("Error in Clock. Couldn't get data as utf8", log: .clock, type: .error)
@@ -47,7 +47,7 @@ struct Clock: ParseObject {
         do {
             cloudVector = try JSONDecoder().decode(OCKRevisionRecord.KnowledgeVector.self, from: data)
         } catch {
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.clock.error("Clock.decodeClock(): \(error.localizedDescription). Vector \(data).")
             } else {
                 os_log("Clock.decodeClock(): %{public}@. Vector %{public}@.", log: .clock, type: .error, error.localizedDescription, data.description)
@@ -64,7 +64,7 @@ struct Clock: ParseObject {
             self.vector = cloudVectorString
             return self.vector
         } catch {
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.clock.error("Clock.encodeClock(): \(error.localizedDescription).")
             } else {
                 os_log("Clock.decodeClock(): %{public}@.", log: .clock, type: .error, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -144,7 +144,7 @@ public final class CarePlan: PCKVersionable {
             return
         }
         
-        let query = Self.query(kPCKObjectableUUIDKey == uuid)
+        let query = Self.query(ObjectableKey.uuid == uuid)
         query.first(callbackQueue: .main){
             result in
             
@@ -191,8 +191,8 @@ public final class CarePlan: PCKVersionable {
         }
         
         //Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousVersionUUID]))
-            .include([kPCKCarePlanPatientKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Self.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
+            .include([CarePlanKey.patient, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main) {
             results in
             
@@ -244,9 +244,9 @@ public final class CarePlan: PCKVersionable {
     
     public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
-        let query = Self.query(kPCKObjectableClockKey >= localClock)
-            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Self.query(ObjectableKey.logicalClock >= localClock)
+            .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -264,9 +264,9 @@ public final class CarePlan: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
+                        Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .carePlan, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .carePlan, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -111,6 +111,11 @@ public final class CarePlan: PCKVersionable {
     /// A title describing this care plan.
     public var title:String?
     
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) title=\(String(describing: title)) patientUUID=\(String(describing: patientUUID)) patient=\(String(describing: patient))"
+    }
+    
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -124,9 +124,9 @@ public final class CarePlan: PCKVersionable {
             return try Self.copyCareKit(entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
@@ -167,9 +167,9 @@ public final class CarePlan: PCKVersionable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.carePlan.error("addToCloud(), \(error.localizedDescription)")
+                        Logger.carePlan.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("addToCloud(), %{public}@", log: .carePlan, type: .error, error.localizedDescription)
+                        os_log("addToCloud(), %{private}@", log: .carePlan, type: .error, error.localizedDescription)
                     }
                     completion(.failure(error))
                 }
@@ -227,9 +227,9 @@ public final class CarePlan: PCKVersionable {
                 }
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.carePlan.error("updateCloud(), \(error.localizedDescription)")
+                    Logger.carePlan.error("updateCloud(), \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("updateCloud(), %{public}", log: .carePlan, type: .error, error.localizedDescription)
+                    os_log("updateCloud(), %{private}", log: .carePlan, type: .error, error.localizedDescription)
                 }
                 completion(.failure(error))
             }
@@ -259,15 +259,15 @@ public final class CarePlan: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                        Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .carePlan, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .carePlan, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.carePlan.debug("An unexpected error occured \(error.localizedDescription)")
+                        Logger.carePlan.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{public}", log: .carePlan, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}", log: .carePlan, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -337,7 +337,7 @@ public final class CarePlan: PCKVersionable {
     }
     
     //Note that CarePlans have to be saved to CareKit first in order to properly convert to CareKit
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKCarePlan {
+    public func convertToCareKit() throws -> OCKCarePlan {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKCarePlan.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -22,19 +22,19 @@ import os.log
 public final class CarePlan: PCKVersionable {
     public var effectiveDate: Date?
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
-    public internal(set) var deletedDate: Date?
+    public var deletedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -52,7 +52,7 @@ public final class CarePlan: PCKVersionable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
@@ -66,13 +66,13 @@ public final class CarePlan: PCKVersionable {
 
     public var ACL: ParseACL?
 
-    public internal(set) var nextVersion: CarePlan? {
+    public var nextVersion: CarePlan? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
 
-    public internal(set) var nextVersionUUID: UUID? {
+    public var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -80,13 +80,13 @@ public final class CarePlan: PCKVersionable {
         }
     }
 
-    public internal(set) var previousVersion: CarePlan? {
+    public var previousVersion: CarePlan? {
         didSet {
             previousVersionUUID = previousVersion?.uuid
         }
     }
 
-    public internal(set) var previousVersionUUID: UUID? {
+    public var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
                 previousVersion = nil

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ParseSwift
 import CareKitStore
+import os.log
 
 /// An `CarePlan` is the ParseCareKit equivalent of `OCKCarePlan`.  An `OCKCarePlan` represents a set of tasks, including both
 /// interventions and assesments, that a patient is supposed to complete as part of his
@@ -122,7 +123,11 @@ public final class CarePlan: PCKVersionable {
         case .carePlan(let entity):
             return try Self.copyCareKit(entity)
         default:
-            print("Error in \(className).new(with:). The wrong type of entity was passed \(careKitEntity)")
+            if #available(iOS 14.0, *) {
+                Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+            } else {
+                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
+            }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
@@ -161,7 +166,11 @@ public final class CarePlan: PCKVersionable {
                     self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    print("Error in \(self.className).addToCloud(). \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.carePlan.error("addToCloud(), \(error.localizedDescription)")
+                    } else {
+                        os_log("addToCloud(), %{public}@", log: .carePlan, type: .error, error.localizedDescription)
+                    }
                     completion(.failure(error))
                 }
             }
@@ -171,13 +180,13 @@ public final class CarePlan: PCKVersionable {
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
         guard let _ = PCKUser.current,
               let uuid = self.uuid,
-            let previousCarePlanUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else{
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
         
         //Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousCarePlanUUID]))
+        let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousVersionUUID]))
             .include([kPCKCarePlanPatientKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main) {
             results in
@@ -187,12 +196,20 @@ public final class CarePlan: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    print("Warning in \(self.className).updateCloud(). A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
+                    if #available(iOS 14.0, *) {
+                        Logger.carePlan.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
+                    } else {
+                        os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .carePlan, type: .debug)
+                    }
                     self.addToCloud(overwriteRemote: false, completion: completion)
                 case 1:
                     //This is the typical case
                     guard let previousVersion = foundObjects.first(where: {$0.uuid == self.previousVersionUUID}) else {
-                        print("Error in \(self.className).updateCloud(). Didn't find previousVersion and this UUID already exists in Cloud")
+                        if #available(iOS 14.0, *) {
+                            Logger.carePlan.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
+                        } else {
+                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, previousVersionUUID.uuidString)
+                        }
                         completion(.failure(ParseCareKitError.uuidAlreadyExists))
                         return
                     }
@@ -201,11 +218,19 @@ public final class CarePlan: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    print("Error in \(self.className).updateCloud(). UUID already exists in Cloud")
+                    if #available(iOS 14.0, *) {
+                        Logger.carePlan.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
+                    } else {
+                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, uuid.uuidString)
+                    }
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                print("Error in \(self.className).updateCloud(). \(error.localizedDescription)")
+                if #available(iOS 14.0, *) {
+                    Logger.carePlan.error("updateCloud(), \(error.localizedDescription)")
+                } else {
+                    os_log("updateCloud(), %{public}", log: .carePlan, type: .error, error.localizedDescription)
+                }
                 completion(.failure(error))
             }
             
@@ -233,9 +258,17 @@ public final class CarePlan: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    print("Warning, table CarePlan either doesn't exist or is missing the column \(kPCKObjectableClockKey). It should be fixed during the first sync of an Outcome... \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                    } else {
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .carePlan, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                    }
                 default:
-                    print("An unexpected error occured \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.carePlan.debug("An unexpected error occured \(error.localizedDescription)")
+                    } else {
+                        os_log("An unexpected error occured \"%{public}", log: .carePlan, type: .debug, error.localizedDescription)
+                    }
                 }
                 mergeRevision(revision)
             }

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -123,7 +123,7 @@ public final class CarePlan: PCKVersionable {
         case .carePlan(let entity):
             return try Self.copyCareKit(entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
@@ -166,7 +166,7 @@ public final class CarePlan: PCKVersionable {
                     self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.error("addToCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("addToCloud(), %{public}@", log: .carePlan, type: .error, error.localizedDescription)
@@ -196,7 +196,7 @@ public final class CarePlan: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
                     } else {
                         os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .carePlan, type: .debug)
@@ -205,7 +205,7 @@ public final class CarePlan: PCKVersionable {
                 case 1:
                     //This is the typical case
                     guard let previousVersion = foundObjects.first(where: {$0.uuid == self.previousVersionUUID}) else {
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.carePlan.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
                             os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, previousVersionUUID.uuidString)
@@ -218,7 +218,7 @@ public final class CarePlan: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
                         os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, uuid.uuidString)
@@ -226,7 +226,7 @@ public final class CarePlan: PCKVersionable {
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.carePlan.error("updateCloud(), \(error.localizedDescription)")
                 } else {
                     os_log("updateCloud(), %{public}", log: .carePlan, type: .error, error.localizedDescription)
@@ -258,13 +258,13 @@ public final class CarePlan: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
                     } else {
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .carePlan, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("An unexpected error occured \(error.localizedDescription)")
                     } else {
                         os_log("An unexpected error occured \"%{public}", log: .carePlan, type: .debug, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -11,66 +11,68 @@ import ParseSwift
 import CareKitStore
 import os.log
 
-/// An `CarePlan` is the ParseCareKit equivalent of `OCKCarePlan`.  An `OCKCarePlan` represents a set of tasks, including both
-/// interventions and assesments, that a patient is supposed to complete as part of his
-/// or her treatment for a specific condition. For example, a care plan for obesity may include tasks requiring the patient to exercise, record their
-/// weight, and log meals. As the care plan evolves with the patient's progress, the care provider may modify the exercises and include notes each
+// swiftlint:disable line_length
+
+/// An `CarePlan` is the ParseCareKit equivalent of `OCKCarePlan`.  An `OCKCarePlan` represents
+/// a set of tasks, including both interventions and assesments, that a patient is supposed to
+/// complete as part of his or her treatment for a specific condition. For example, a care plan for obesity
+/// may include tasks requiring the patient to exercise, record their weight, and log meals. As the care
+/// plan evolves with the patient's progress, the care provider may modify the exercises and include notes each
 /// time about why the changes were made.
 public final class CarePlan: PCKVersionable {
     public var effectiveDate: Date?
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public internal(set) var deletedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
 
     public internal(set) var nextVersion: CarePlan? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
-    
-    public internal(set) var nextVersionUUID:UUID? {
+
+    public internal(set) var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -83,7 +85,7 @@ public final class CarePlan: PCKVersionable {
             previousVersionUUID = previousVersion?.uuid
         }
     }
-    
+
     public internal(set) var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
@@ -93,32 +95,34 @@ public final class CarePlan: PCKVersionable {
     }
 
     /// The patient to whom this care plan belongs.
-    public var patient:Patient? {
+    public var patient: Patient? {
         didSet {
             patientUUID = patient?.uuid
         }
     }
-    
+
     /// The UUID of the patient to whom this care plan belongs.
-    public var patientUUID:UUID? {
-        didSet{
+    public var patientUUID: UUID? {
+        didSet {
             if patientUUID != patient?.uuid {
                 patient = nil
             }
         }
     }
-    
+
     /// A title describing this care plan.
-    public var title:String?
-    
+    public var title: String?
+
     /// A textual representation of this instance, suitable for debugging.
     public var localizedDescription: String {
         "\(debugDescription) title=\(String(describing: title)) patientUUID=\(String(describing: patientUUID)) patient=\(String(describing: patient))"
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate,
+             timezone, userInfo, groupIdentifier, tags, source, asset, remoteID,
+             notes, logicalClock
         case previousVersionUUID, nextVersionUUID, previousVersion, nextVersion, effectiveDate
         case title, patient, patientUUID
     }
@@ -131,32 +135,32 @@ public final class CarePlan: PCKVersionable {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.carePlan.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.",
+                       log: .carePlan, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
-    
-    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: .main){
-            result in
-            
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundEntity):
                 guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                     return
                 }
-                
+
                 if overwriteRemote {
                     self.updateCloud(completion: completion)
                 } else {
@@ -167,7 +171,8 @@ public final class CarePlan: PCKVersionable {
             case .failure(let error):
 
                 switch error.code {
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
                     self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
@@ -181,25 +186,24 @@ public final class CarePlan: PCKVersionable {
             }
         }
     }
-    
-    public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
+
+    public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
               let uuid = self.uuid,
-            let previousVersionUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
             .include([CarePlanKey.patient, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main) {
-            results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let foundObjects):
-                switch foundObjects.count{
+                switch foundObjects.count {
                 case 0:
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
@@ -213,7 +217,8 @@ public final class CarePlan: PCKVersionable {
                         if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.carePlan.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
-                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, previousVersionUUID.uuidString)
+                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud",
+                                   log: .carePlan, type: .error, previousVersionUUID.uuidString)
                         }
                         completion(.failure(ParseCareKitError.uuidAlreadyExists))
                         return
@@ -226,7 +231,8 @@ public final class CarePlan: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
-                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .carePlan, type: .error, uuid.uuidString)
+                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud",
+                               log: .carePlan, type: .error, uuid.uuidString)
                     }
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
@@ -238,30 +244,33 @@ public final class CarePlan: PCKVersionable {
                 }
                 completion(.failure(error))
             }
-            
+
         }
     }
-    
-    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
-        
+
+    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                              mergeRevision: @escaping (OCKRevisionRecord) -> Void) {
+
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let carePlans):
-                let pulled = carePlans.compactMap{try? $0.convertToCareKit()}
-                let entities = pulled.compactMap{OCKEntity.carePlan($0)}
+                let pulled = carePlans.compactMap {try? $0.convertToCareKit()}
+                let entities = pulled.compactMap {OCKEntity.carePlan($0)}
                 let revision = OCKRevisionRecord(entities: entities, knowledgeVector: cloudClock)
                 mergeRevision(revision)
             case .failure(let error):
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: cloudClock)
-                
-                switch error.code{
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                    //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
+
+                switch error.code {
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
+                    //If the query was looking in a column that wasn't a default column,
+                    //it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
@@ -272,23 +281,24 @@ public final class CarePlan: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.carePlan.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{private}", log: .carePlan, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}",
+                               log: .carePlan, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
             }
         }
     }
-    
-    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
+
+    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
         self.logicalClock = cloudClock //Stamp Entity
-        
-        guard let _ = self.previousVersionUUID else{
+
+        guard self.previousVersionUUID != nil else {
             self.addToCloud(overwriteRemote: overwriteRemote) { result in
-                
+
                 switch result {
-                
-                case .success(_):
+
+                case .success:
                     completion(nil)
                 case .failure(let error):
                     completion(error)
@@ -296,19 +306,19 @@ public final class CarePlan: PCKVersionable {
             }
             return
         }
-        
+
         self.updateCloud { result in
-            
+
             switch result {
-            
-            case .success(_):
+
+            case .success:
                 completion(nil)
             case .failure(let error):
                 completion(error)
             }
         }
     }
-    
+
     public static func copyValues(from other: CarePlan, to here: CarePlan) throws -> Self {
         var here = here
         here.copyVersionedValues(from: other)
@@ -320,10 +330,10 @@ public final class CarePlan: PCKVersionable {
         }
         return copied
     }
-    
+
     public class func copyCareKit(_ carePlanAny: OCKAnyCarePlan) throws -> CarePlan {
-        
-        guard let carePlan = carePlanAny as? OCKCarePlan else{
+
+        guard let carePlan = carePlanAny as? OCKCarePlan else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
         let encoded = try ParseCareKitUtility.encoder().encode(carePlan)
@@ -341,41 +351,41 @@ public final class CarePlan: PCKVersionable {
             $0.encodingForParse = encodingForParse
         }
     }
-    
+
     //Note that CarePlans have to be saved to CareKit first in order to properly convert to CareKit
     public func convertToCareKit() throws -> OCKCarePlan {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKCarePlan.self, from: encoded)
     }
-    
+
     ///Link versions and related classes
-    public func linkRelated(completion: @escaping(Result<CarePlan,Error>)->Void){
+    public func linkRelated(completion: @escaping(Result<CarePlan, Error>) -> Void) {
         self.linkVersions { result in
-            
+
             var updatedCarePlan: CarePlan
-            
+
             switch result {
-            
+
             case .success(let linked):
                 updatedCarePlan = linked
-                
-            case .failure(_):
+
+            case .failure:
                 updatedCarePlan = self
             }
-            
-            guard let patientUUID = self.patientUUID else{
+
+            guard let patientUUID = self.patientUUID else {
                 //Finished if there's no Patient, otherwise see if it's in the cloud
                 completion(.success(updatedCarePlan))
                 return
             }
-            
+
             Patient.first(patientUUID, relatedObject: updatedCarePlan.patient) { result in
-                
+
                 if case let .success(patient) = result {
                     updatedCarePlan.patient = patient
                 }
-                
+
                 completion(.success(updatedCarePlan))
             }
         }

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -61,7 +61,7 @@ public final class CarePlan: PCKVersionable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
 
     public internal(set) var nextVersion: CarePlan? {
@@ -329,6 +329,7 @@ public final class CarePlan: PCKVersionable {
         let encoded = try ParseCareKitUtility.encoder().encode(carePlan)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = carePlan.id
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -13,16 +13,16 @@ import os.log
 
 struct Clock: ParseObject {
     var objectId: String?
-    
-    var createdAt: Date?
-    
-    var updatedAt: Date?
-    
-    var ACL: ParseACL?
-    
-    var uuid:UUID?
 
-    var vector:String?
+    var createdAt: Date?
+
+    var updatedAt: Date?
+
+    var ACL: ParseACL?
+
+    var uuid: UUID?
+
+    var vector: String?
 
     public var localizedDescription: String {
         "\(debugDescription) vector=\(String(describing: vector))"
@@ -32,8 +32,8 @@ struct Clock: ParseObject {
         self.uuid = uuid
         self.vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
     }
-    
-    func decodeClock(completion:@escaping(OCKRevisionRecord.KnowledgeVector?)->Void){
+
+    func decodeClock(completion:@escaping(OCKRevisionRecord.KnowledgeVector?) -> Void) {
         guard let data = self.vector?.data(using: .utf8) else {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.clock.error("Error in Clock. Couldn't get data as utf8")
@@ -42,23 +42,25 @@ struct Clock: ParseObject {
             }
             return
         }
-        
-        let cloudVector:OCKRevisionRecord.KnowledgeVector?
+
+        let cloudVector: OCKRevisionRecord.KnowledgeVector?
         do {
             cloudVector = try JSONDecoder().decode(OCKRevisionRecord.KnowledgeVector.self, from: data)
         } catch {
             if #available(iOS 14.0, watchOS 7.0, *) {
+                // swiftlint:disable:next line_length
                 Logger.clock.error("Clock.decodeClock(): \(error.localizedDescription, privacy: .private). Vector \(data, privacy: .private).")
             } else {
-                os_log("Clock.decodeClock(): %{private}@. Vector %{private}@.", log: .clock, type: .error, error.localizedDescription, data.debugDescription)
+                os_log("Clock.decodeClock(): %{private}@. Vector %{private}@.",
+                       log: .clock, type: .error, error.localizedDescription, data.debugDescription)
             }
             cloudVector = nil
         }
         completion(cloudVector)
     }
-    
-    mutating func encodeClock(_ clock: OCKRevisionRecord.KnowledgeVector)->String?{
-        do{
+
+    mutating func encodeClock(_ clock: OCKRevisionRecord.KnowledgeVector) -> String? {
+        do {
             let json = try JSONEncoder().encode(clock)
             let cloudVectorString = String(data: json, encoding: .utf8)!
             self.vector = cloudVectorString
@@ -72,29 +74,28 @@ struct Clock: ParseObject {
             return nil
         }
     }
-    
-    static func fetchFromCloud(uuid:UUID, createNewIfNeeded:Bool, completion:@escaping(Clock?, OCKRevisionRecord.KnowledgeVector?, ParseError?)->Void){
-        
+
+    static func fetchFromCloud(uuid: UUID, createNewIfNeeded: Bool,
+                               completion:@escaping(Clock?, OCKRevisionRecord.KnowledgeVector?, ParseError?) -> Void) {
+
         //Fetch Clock from Cloud
         let query = Clock.query(ClockKey.uuid == uuid)
         query.first(callbackQueue: .main) { result in
-            
+
             switch result {
-            
+
             case .success(let foundVector):
-                foundVector.decodeClock(){
-                    possiblyDecoded in
+                foundVector.decodeClock { possiblyDecoded in
                     completion(foundVector, possiblyDecoded, nil)
                 }
             case .failure(let error):
-                if !createNewIfNeeded{
+                if !createNewIfNeeded {
                     completion(nil, nil, error)
-                }else{
+                } else {
                     //This is the first time the Clock is user setup for this user
                     let newVector = Clock(uuid: uuid)
-                    newVector.decodeClock(){
-                        possiblyDecoded in
-                        completion(newVector,possiblyDecoded,error)
+                    newVector.decodeClock { possiblyDecoded in
+                        completion(newVector, possiblyDecoded, error)
                     }
                 }
             }

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -76,7 +76,7 @@ struct Clock: ParseObject {
     static func fetchFromCloud(uuid:UUID, createNewIfNeeded:Bool, completion:@escaping(Clock?, OCKRevisionRecord.KnowledgeVector?, ParseError?)->Void){
         
         //Fetch Clock from Cloud
-        let query = Clock.query(kPCKClockPatientTypeUUIDKey == uuid)
+        let query = Clock.query(ClockKey.uuid == uuid)
         query.first(callbackQueue: .main) { result in
             
             switch result {

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -137,6 +137,11 @@ public final class Contact: PCKVersionable {
     /// An array of other information that could be used reach this contact.
     public var otherContactInfo: [OCKLabeledValue]?
 
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) title=\(String(describing: title)) role=\(String(describing: role)) organization=\(String(describing: organization)) category=\(String(describing: category)) address=\(String(describing: address)) messagingNumbers=\(String(describing: messagingNumbers)) emailAddresses=\(String(describing: emailAddresses)) phoneNumbers=\(String(describing: phoneNumbers)) otherContactInfo=\(String(describing: otherContactInfo)) carePlanUUID=\(String(describing: carePlanUUID)) carePlan=\(String(describing: carePlan))"
+    }
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -369,7 +369,7 @@ public final class Contact: PCKVersionable {
         }
     }
 
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKContact {
+    public func convertToCareKit() throws -> OCKContact {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -20,13 +20,13 @@ import os.log
 /// least a name, and may optionally have numerous other addresses at which to be contacted.
 // swiftlint:disable:next type_body_length
 public final class Contact: PCKVersionable {
-    public internal(set) var nextVersion: Contact? {
+    public var nextVersion: Contact? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
 
-    public internal(set) var nextVersionUUID: UUID? {
+    public var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -34,13 +34,13 @@ public final class Contact: PCKVersionable {
         }
     }
 
-    public internal(set) var previousVersion: Contact? {
+    public var previousVersion: Contact? {
         didSet {
             previousVersionUUID = previousVersion?.uuid
         }
     }
 
-    public internal(set) var previousVersionUUID: UUID? {
+    public var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
                 previousVersion = nil
@@ -50,19 +50,19 @@ public final class Contact: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
-    public internal(set) var deletedDate: Date?
+    public var deletedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -80,7 +80,7 @@ public final class Contact: PCKVersionable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -87,7 +87,7 @@ public final class Contact: PCKVersionable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
     /// The contact's postal address.
     public var address:OCKPostalAddress?
@@ -362,6 +362,7 @@ public final class Contact: PCKVersionable {
         let encoded = try ParseCareKitUtility.encoder().encode(contact)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = contact.id
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
     

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -152,9 +152,9 @@ public final class Contact: PCKVersionable {
             return try Self.copyCareKit(entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.contact.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.contact.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .contact, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .contact, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
@@ -195,9 +195,9 @@ public final class Contact: PCKVersionable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.contact.error("addToCloud(), \(error.localizedDescription)")
+                        Logger.contact.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("addToCloud(), %{public}@", log: .contact, type: .error, error.localizedDescription)
+                        os_log("addToCloud(), %{private}@", log: .contact, type: .error, error.localizedDescription)
                     }
                     completion(.failure( error))
                 }
@@ -254,9 +254,9 @@ public final class Contact: PCKVersionable {
                 }
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.contact.error("updateCloud(), \(error.localizedDescription)")
+                    Logger.contact.error("updateCloud(), \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("updateCloud(), %{public}", log: .contact, type: .error, error.localizedDescription)
+                    os_log("updateCloud(), %{private}", log: .contact, type: .error, error.localizedDescription)
                 }
                 completion(.failure(error))
             }
@@ -286,15 +286,15 @@ public final class Contact: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                        Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .contact, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .contact, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.contact.debug("An unexpected error occured \(error.localizedDescription)")
+                        Logger.contact.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{public}", log: .contact, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}", log: .contact, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -151,7 +151,7 @@ public final class Contact: PCKVersionable {
         case .contact(let entity):
             return try Self.copyCareKit(entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.contact.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .contact, type: .error, careKitEntity.entityType.debugDescription)
@@ -194,7 +194,7 @@ public final class Contact: PCKVersionable {
                         self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.error("addToCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("addToCloud(), %{public}@", log: .contact, type: .error, error.localizedDescription)
@@ -223,7 +223,7 @@ public final class Contact: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
                     } else {
                         os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .contact, type: .debug)
@@ -232,7 +232,7 @@ public final class Contact: PCKVersionable {
                 case 1:
                     //This is the typical case
                     guard let previousVersion = foundObjects.first(where: {$0.uuid == previousVersionUUID}) else {
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.contact.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
                             os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .contact, type: .error, previousVersionUUID.uuidString)
@@ -245,7 +245,7 @@ public final class Contact: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
                         os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .contact, type: .error, uuid.uuidString)
@@ -253,7 +253,7 @@ public final class Contact: PCKVersionable {
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.contact.error("updateCloud(), \(error.localizedDescription)")
                 } else {
                     os_log("updateCloud(), %{public}", log: .contact, type: .error, error.localizedDescription)
@@ -285,13 +285,13 @@ public final class Contact: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
                     } else {
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .contact, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("An unexpected error occured \(error.localizedDescription)")
                     } else {
                         os_log("An unexpected error occured \"%{public}", log: .contact, type: .debug, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -11,17 +11,22 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable line_length
+// swiftlint:disable function_body_length
+
 /// An `Contact` is the ParseCareKit equivalent of `OCKContact`.  An `OCKContact`represents a contact that a user
-/// may want to get in touch with. A contact may be a care provider, a friend, or a family
-/// member. Contacts must have at least a name, and may optionally have numerous other addresses at which to be contacted.
+/// may want to get in touch with. A contact may be a care provider, a friend, or a family member. Contacts must have at
+/// least a name, and may optionally have numerous other addresses at which to be contacted.
+// swiftlint:disable:next type_body_length
 public final class Contact: PCKVersionable {
     public internal(set) var nextVersion: Contact? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
-    
-    public internal(set) var nextVersionUUID:UUID? {
+
+    public internal(set) var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -34,7 +39,7 @@ public final class Contact: PCKVersionable {
             previousVersionUUID = previousVersion?.uuid
         }
     }
-    
+
     public internal(set) var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
@@ -42,87 +47,87 @@ public final class Contact: PCKVersionable {
             }
         }
     }
-    
+
     public var effectiveDate: Date?
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public internal(set) var deletedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
+
     /// The contact's postal address.
-    public var address:OCKPostalAddress?
-    
+    public var address: OCKPostalAddress?
+
     /// Indicates if this contact is care provider or if they are a friend or family member.
-    public var category:OCKContactCategory?
-    
+    public var category: OCKContactCategory?
+
     /// The contact's name.
-    public var name:PersonNameComponents
-    
+    public var name: PersonNameComponents
+
     /// The organization this contact belongs to.
-    public var organization:String?
-    
+    public var organization: String?
+
     /// A description of what this contact's role is.
-    public var role:String?
-    
+    public var role: String?
+
     /// A title for this contact.
-    public var title:String?
-    
+    public var title: String?
+
     /// The version in the local database for the care plan associated with this contact.
-    public var carePlan:CarePlan? {
+    public var carePlan: CarePlan? {
         didSet {
             carePlanUUID = carePlan?.uuid
         }
     }
-    
+
     /// The version id in the local database for the care plan associated with this contact.
-    public var carePlanUUID:UUID? {
-        didSet{
+    public var carePlanUUID: UUID? {
+        didSet {
             if carePlanUUID != carePlan?.uuid {
                 carePlan = nil
             }
         }
     }
-    
+
     /// An array of numbers that the contact can be messaged at.
     /// The number strings may contains non-numeric characters.
     public var messagingNumbers: [OCKLabeledValue]?
@@ -144,14 +149,16 @@ public final class Contact: PCKVersionable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate,
+             timezone, userInfo, groupIdentifier, tags, source, asset, remoteID,
+             notes, logicalClock
         case previousVersionUUID, nextVersionUUID, previousVersion, nextVersion, effectiveDate
         case carePlan, title, carePlanUUID, address, category, name, organization, role
         case emailAddresses, messagingNumbers, phoneNumbers, otherContactInfo
     }
 
     public func new(with careKitEntity: OCKEntity) throws -> Contact {
-        
+
         switch careKitEntity {
         case .contact(let entity):
             return try Self.copyCareKit(entity)
@@ -159,33 +166,34 @@ public final class Contact: PCKVersionable {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.contact.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .contact, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.",
+                       log: .contact, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
-    
-    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if already in the cloud
         let query = Contact.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: .main){ result in
-            
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundEntity):
                 guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                     return
                 }
-                
+
                 if overwriteRemote {
                     self.updateCloud(completion: completion)
                 } else {
@@ -195,7 +203,8 @@ public final class Contact: PCKVersionable {
 
             case .failure(let error):
                 switch error.code {
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
+                //1 - this column hasn't been added. 101 - Query returned no results
+                case .internalServer, .objectNotFound:
                         self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
@@ -209,29 +218,30 @@ public final class Contact: PCKVersionable {
             }
         }
     }
-    
-    public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
+
+    public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
               let uuid = self.uuid,
-            let previousVersionUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Contact.query(containedIn(key: ObjectableKey.uuid, array: [uuid,previousVersionUUID]))
+        let query = Contact.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
             .include([ContactKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let foundObjects):
-                switch foundObjects.count{
+                switch foundObjects.count {
                 case 0:
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
                     } else {
-                        os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .contact, type: .debug)
+                        os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new",
+                               log: .contact, type: .debug)
                     }
                     self.addToCloud(overwriteRemote: false, completion: completion)
                 case 1:
@@ -240,7 +250,8 @@ public final class Contact: PCKVersionable {
                         if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.contact.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
-                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .contact, type: .error, previousVersionUUID.uuidString)
+                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud",
+                                   log: .contact, type: .error, previousVersionUUID.uuidString)
                         }
                         completion(.failure(ParseCareKitError.uuidAlreadyExists))
                         return
@@ -253,7 +264,8 @@ public final class Contact: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
-                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .contact, type: .error, uuid.uuidString)
+                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud",
+                               log: .contact, type: .error, uuid.uuidString)
                     }
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
@@ -267,29 +279,32 @@ public final class Contact: PCKVersionable {
             }
         }
     }
-    
-    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
-        
+
+    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                              mergeRevision: @escaping (OCKRevisionRecord) -> Void) {
+
         let query = Contact.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .include([ContactKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let carePlans):
-                let pulled = carePlans.compactMap{try? $0.convertToCareKit()}
-                let entities = pulled.compactMap{OCKEntity.contact($0)}
+                let pulled = carePlans.compactMap {try? $0.convertToCareKit()}
+                let entities = pulled.compactMap {OCKEntity.contact($0)}
                 let revision = OCKRevisionRecord(entities: entities, knowledgeVector: cloudClock)
                 mergeRevision(revision)
 
             case .failure(let error):
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: cloudClock)
-                
-                switch error.code{
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                    //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
-                    //Saving the new item with the custom column should resolve the issue
+
+                switch error.code {
+                //1 - this column hasn't been added. 101 - Query returned no results
+                //If the query was looking in a column that wasn't a default column,
+                //it will return nil if the table doesn't contain the custom column
+                //Saving the new item with the custom column should resolve the issue
+                case .internalServer, .objectNotFound:
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
@@ -299,24 +314,25 @@ public final class Contact: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.contact.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{private}", log: .contact, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}",
+                               log: .contact, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
             }
         }
     }
-    
-    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
-        
+
+    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+
         self.logicalClock = cloudClock //Stamp Entity
-        
-        guard let _ = self.previousVersionUUID else {
+
+        guard self.previousVersionUUID != nil else {
             self.addToCloud(overwriteRemote: overwriteRemote) { result in
-                
+
                 switch result {
-                
-                case .success(_):
+
+                case .success:
                     completion(nil)
                 case .failure(let error):
                     completion(error)
@@ -324,19 +340,19 @@ public final class Contact: PCKVersionable {
             }
             return
         }
-        
+
         self.updateCloud { result in
-            
+
             switch result {
-            
-            case .success(_):
+
+            case .success:
                 completion(nil)
             case .failure(let error):
                 completion(error)
             }
         }
     }
-    
+
     public class func copyValues(from other: Contact, to here: Contact) throws -> Self {
         var copy = here
         copy.copyVersionedValues(from: other)
@@ -347,7 +363,7 @@ public final class Contact: PCKVersionable {
         copy.organization = other.organization
         copy.role = other.role
         copy.carePlan = other.carePlan
-        
+
         guard let copied = copy as? Self else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
@@ -355,8 +371,8 @@ public final class Contact: PCKVersionable {
     }
 
     public class func copyCareKit(_ contactAny: OCKAnyContact) throws -> Contact {
-        
-        guard let contact = contactAny as? OCKContact else{
+
+        guard let contact = contactAny as? OCKContact else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
         let encoded = try ParseCareKitUtility.encoder().encode(contact)
@@ -365,7 +381,7 @@ public final class Contact: PCKVersionable {
         decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
-    
+
     func prepareEncodingRelational(_ encodingForParse: Bool) {
         previousVersion?.encodingForParse = encodingForParse
         nextVersion?.encodingForParse = encodingForParse
@@ -380,33 +396,33 @@ public final class Contact: PCKVersionable {
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKContact.self, from: encoded)
     }
-    
+
     ///Link versions and related classes
-    public func linkRelated(completion: @escaping(Result<Contact,Error>)->Void){
+    public func linkRelated(completion: @escaping(Result<Contact, Error>) -> Void) {
         self.linkVersions { result in
-            
+
             var updatedContact: Contact
-            
+
             switch result {
-            
+
             case .success(let linked):
                 updatedContact = linked
-            case .failure(_):
+            case .failure:
                 updatedContact = self
             }
-            
-            guard let carePlanUUID = self.carePlanUUID else{
+
+            guard let carePlanUUID = self.carePlanUUID else {
                 //Finished if there's no CarePlan, otherwise see if it's in the cloud
                 completion(.success(updatedContact))
                 return
             }
-            
+
             CarePlan.first(carePlanUUID, relatedObject: updatedContact.carePlan) { result in
-                
+
                 if case let .success(carePlan) = result {
                     updatedContact.carePlan = carePlan
                 }
-                
+
                 completion(.success(updatedContact))
             }
         }
@@ -416,11 +432,11 @@ public final class Contact: PCKVersionable {
 extension Contact {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        
+
         if encodingForParse {
             try container.encodeIfPresent(carePlan, forKey: .carePlan)
         }
-        
+
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(carePlanUUID, forKey: .carePlanUUID)
         try container.encodeIfPresent(address, forKey: .address)
@@ -435,4 +451,4 @@ extension Contact {
         try encodeVersionable(to: encoder)
         encodingForParse = true
     }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -174,7 +174,7 @@ public final class Contact: PCKVersionable {
         }
         
         //Check to see if already in the cloud
-        let query = Contact.query(kPCKObjectableUUIDKey == uuid)
+        let query = Contact.query(ObjectableKey.uuid == uuid)
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -219,8 +219,8 @@ public final class Contact: PCKVersionable {
         }
         
         //Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Contact.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
-            .include([kPCKContactCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Contact.query(containedIn(key: ObjectableKey.uuid, array: [uuid,previousVersionUUID]))
+            .include([ContactKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -270,9 +270,9 @@ public final class Contact: PCKVersionable {
     
     public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
-        let query = Contact.query(kPCKObjectableClockKey >= localClock)
-            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKContactCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Contact.query(ObjectableKey.logicalClock >= localClock)
+            .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
+            .include([ContactKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -291,9 +291,9 @@ public final class Contact: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
+                        Logger.contact.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .contact, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .contact, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -67,6 +67,11 @@ open class Note: PCKObjectable {
     /// The person who created this note.
     public var author:String?
     
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) title=\(String(describing: title)) content=\(String(describing: content)) author=\(String(describing: author))"
+    }
+    
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -56,7 +56,7 @@ open class Note: PCKObjectable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
     /// The note content.
     public var content:String?
@@ -97,7 +97,9 @@ open class Note: PCKObjectable {
     
     open class func copyCareKit(_ note: OCKNote) throws -> Note {
         let encoded = try ParseCareKitUtility.encoder().encode(note)
-        return try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
+        let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
+        decoded.ACL = try? ParseACL.defaultACL()
+        return decoded
     }
     
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -96,7 +96,7 @@ open class Note: PCKObjectable {
     }
     
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
-    open func convertToCareKit(fromCloud:Bool=true) throws -> OCKNote {
+    open func convertToCareKit() throws -> OCKNote {
         encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKNote.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -12,69 +12,71 @@ import CareKitStore
 
 /// An `Note` is the ParseCareKit equivalent of `OCKNote`.  `OCKNote` can be attached to all other
 /// CareKit objects and values. Use cases may include a physician leaving a note on a task when it is modified
-/// to explain why a medication dose was changed, or a note left from a patient to a care provider explaining why they weren't able to complete a
-/// task on a certain occasion.
+/// to explain why a medication dose was changed, or a note left from a patient to a care provider explaining
+/// why they weren't able to complete a task on a certain occasion.
 open class Note: PCKObjectable {
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
+
     /// The note content.
-    public var content:String?
-    
+    public var content: String?
+
     /// A title for the note.
-    public var title:String?
-    
+    public var title: String?
+
     /// The person who created this note.
-    public var author:String?
-    
+    public var author: String?
+
     /// A textual representation of this instance, suitable for debugging.
     public var localizedDescription: String {
+        // swiftlint:disable:next line_length
         "\(debugDescription) title=\(String(describing: title)) content=\(String(describing: content)) author=\(String(describing: author))"
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
+        case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo,
+             groupIdentifier, tags, source, asset, remoteID, notes
         case content, title, author
     }
 
@@ -94,56 +96,56 @@ open class Note: PCKObjectable {
         }
         return copied
     }
-    
+
     open class func copyCareKit(_ note: OCKNote) throws -> Note {
         let encoded = try ParseCareKitUtility.encoder().encode(note)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
-    
+
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
     open func convertToCareKit() throws -> OCKNote {
         encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKNote.self, from: encoded)
     }
-    
+
     public func prepareEncodingRelational(_ encodingForParse: Bool) {
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }
     }
 
-    func stamp(_ clock: Int){
+    func stamp(_ clock: Int) {
         self.logicalClock = clock
-        self.notes?.forEach{
+        self.notes?.forEach {
             $0.logicalClock = self.logicalClock
         }
     }
-    
-    open class func replaceWithCloudVersion(_ local:inout [Note]?, cloud:[Note]?){
-        guard let _ = local,
-            let _ = cloud else {
+
+    open class func replaceWithCloudVersion(_ local:inout [Note]?, cloud: [Note]?) {
+        guard local != nil,
+            cloud != nil else {
             return
         }
-        
-        for (index,note) in local!.enumerated(){
-            guard let cloudNote = cloud!.first(where: {$0.uuid == note.uuid}) else{
+
+        for (index, note) in local!.enumerated() {
+            guard let cloudNote = cloud!.first(where: {$0.uuid == note.uuid}) else {
                 continue
             }
             local![index] = cloudNote
         }
     }
-    
-    open class func fetchAndReplace(_ notes: [Note]?, completion: @escaping([Note]?)-> Void){
-        let entitiesToFetch = notes?.compactMap{ entity -> UUID? in
-            if entity.objectId == nil{
+
+    open class func fetchAndReplace(_ notes: [Note]?, completion: @escaping([Note]?) -> Void) {
+        let entitiesToFetch = notes?.compactMap { entity -> UUID? in
+            if entity.objectId == nil {
                 return entity.uuid
             }
             return nil
         }
-        
+
         guard let uuids = entitiesToFetch,
               var originalNotes = notes else {
             completion(nil)
@@ -151,26 +153,25 @@ open class Note: PCKObjectable {
         }
         let query = Self.query(containedIn(key: ObjectableKey.uuid, array: uuids))
             .include([ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let localNotes):
                 //var returnNotes = notes!
-                for (index, note) in localNotes.enumerated(){
+                for (index, note) in localNotes.enumerated() {
                     guard let replaceNote = localNotes.first(where: {$0.uuid == note.uuid}),
                           let updatedNote = try? Self.copyValues(from: note, to: replaceNote) else {
                         continue
                     }
-                    
+
                     originalNotes[index] = updatedNote//Copy any changes
                 }
-                
+
                 completion(originalNotes)
-            case .failure(_):
+            case .failure:
                 completion(nil)
             }
         }
     }
 }
-

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -149,8 +149,8 @@ open class Note: PCKObjectable {
             completion(nil)
             return
         }
-        let query = Self.query(containedIn(key: kPCKObjectableUUIDKey, array: uuids))
-            .include([kPCKObjectableNotesKey])
+        let query = Self.query(containedIn(key: ObjectableKey.uuid, array: uuids))
+            .include([ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -16,17 +16,17 @@ import CareKitStore
 /// why they weren't able to complete a task on a certain occasion.
 open class Note: PCKObjectable {
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -44,7 +44,7 @@ open class Note: PCKObjectable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -466,13 +466,6 @@ extension Outcome {
         try container.encodeIfPresent(taskUUID, forKey: .taskUUID)
         try container.encodeIfPresent(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
         try container.encodeIfPresent(values, forKey: .values)
-        /*guard let valuesToEncode = values else {
-            throw ParseCareKitError.requiredValueCantBeUnwrapped
-        }
-        try valuesToEncode.forEach { value in
-            var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .values)
-            try nestedUnkeyedContainer.encode(value)
-        }*/
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         if id.count > 0 {
             entityId = id

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -105,7 +105,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         case .outcome(let entity):
             return try Self.copyCareKit(entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.outcome.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .outcome, type: .error, careKitEntity.entityType.debugDescription)
@@ -169,7 +169,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.error("addToCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("addToCloud(), %{public}@", log: .outcome, type: .error, error.localizedDescription)
@@ -205,13 +205,13 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
                     } else {
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .outcome, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("An unexpected error occured \(error.localizedDescription)")
                     } else {
                         os_log("An unexpected error occured \"%{public}", log: .outcome, type: .debug, error.localizedDescription)
@@ -277,7 +277,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 foundObject.notes?.forEach{ $0.delete(callbackQueue: .main){ _ in } } //CareKit causes ParseCareKit to create new ones of these, this is removing duplicates
                 
                 guard let copied = try? Self.copyValues(from: self, to: foundObject) else {
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("tombstone(), Couldn't cast to self")
                     } else {
                         os_log("tombstone(), Couldn't cast to self", log: .outcome, type: .debug)
@@ -295,7 +295,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
 
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.error("updateCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("updateCloud(), %{public}", log: .outcome, type: .error, error.localizedDescription)
@@ -369,7 +369,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             switch results {
             
             case .success(let saved):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.outcome.debug("save(), Saved: \(saved, privacy: .private)")
                 } else {
                     os_log("save(), Saved: %{private}", log: .outcome, type: .debug, saved.description)
@@ -388,7 +388,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     }
                 }
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.outcome.error("save(), \(error.localizedDescription)")
                 } else {
                     os_log("save(), %{public}", log: .outcome, type: .error, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -11,81 +11,85 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable line_length
+
 /// An `Outcome` is the ParseCareKit equivalent of `OCKOutcome`.  An `OCKOutcome` represents the
 /// outcome of an event corresponding to a task. An outcome may have 0 or more values associated with it.
-/// For example, a task that asks a patient to measure their temperature will have events whose outcome will contain a single value representing
-/// the patient's temperature.
+/// For example, a task that asks a patient to measure their temperature will have events whose outcome
+/// will contain a single value representing the patient's temperature.
+// swiftlint:disable:next type_body_length
 final public class Outcome: PCKObjectable, PCKSynchronizable {
-    
+
     public internal(set) var uuid: UUID?
 
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
+
     var date: Date? //Custom added, check if needed
-    
+
     /// The date on which this object was tombstoned. Note that objects are never actually deleted,
     /// but rather they are tombstoned and will no longer be returned from queries.
     public internal(set) var deletedDate: Date?
-    
+
     /// Specifies how many events occured before this outcome was created. For example, if a task is schedule to happen twice per day, then
     /// the 2nd outcome on the 2nd day will have a `taskOccurrenceIndex` of 3.
     ///
     /// - Note: The task occurrence references a specific version of a task, so if a new version the task is created, the task occurrence index
     ///  will start again from 0.
     public var taskOccurrenceIndex: Int?
-    
+
     /// An array of values associated with this outcome. Most outcomes will have 0 or 1 values, but some may have more.
     /// - Examples:
     ///   - A task to call a physician might have 0 values, or 1 value containing the time stamp of when the call was placed.
     ///   - A task to walk 2,000 steps might have 1 value, with that value being the number of steps that were actually taken.
     ///   - A task to complete a survey might have multiple values corresponding to the answers to the questions in the survey.
     public var values: [OutcomeValue]?
-    
+
     /// The version of the task to which this outcomes belongs.
     public var task: Task? {
         didSet {
             taskUUID = task?.uuid
         }
     }
-    
+
     /// The version ID of the task to which this outcomes belongs.
     public var taskUUID: UUID? {
         didSet {
@@ -102,12 +106,13 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes
+        case uuid, entityId, schemaVersion, createdDate, updatedDate, timezone,
+             userInfo, groupIdentifier, tags, source, asset, remoteID, notes
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
 
     public func new(with careKitEntity: OCKEntity) throws -> Outcome {
-        
+
         switch careKitEntity {
         case .outcome(let entity):
             return try Self.copyCareKit(entity)
@@ -115,33 +120,34 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.outcome.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .outcome, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.",
+                       log: .outcome, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
-    
-    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-            
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if already in the cloud
         let query = Outcome.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: .main){ result in
-            
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundEntity):
                 guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                     return
                 }
-                
+
                 if overwriteRemote {
                     //The tombsone method can handle the overwrite
                     self.tombstone(completion: completion)
@@ -149,31 +155,32 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     //This object already exists on server, ignore gracefully
                     completion(.success(foundEntity))
                 }
-                
+
             case .failure(let error):
-                switch error.code{
+                switch error.code {
                 case .internalServer: //1 - this column hasn't been added.
                     self.save(completion: completion)
                 case .objectNotFound: //101 - Query returned no results
                     guard self.id.count > 0 else {
                         return
                     }
-                    let query = Outcome.query(ObjectableKey.entityId == self.id, doesNotExist(key: OutcomeKey.deletedDate))
+                    let query = Outcome.query(ObjectableKey.entityId == self.id,
+                                              doesNotExist(key: OutcomeKey.deletedDate))
                         .include([OutcomeKey.values, ObjectableKey.notes])
-                    query.first(callbackQueue: .main){ result in
-                        
+                    query.first(callbackQueue: .main) { result in
+
                         switch result {
-                        
+
                         case .success(let objectThatWillBeTombstoned):
                             var objectToAdd = self
                             objectToAdd = objectToAdd.copyRelational(objectThatWillBeTombstoned)
                             objectToAdd.save(completion: completion)
 
-                        case .failure(_):
+                        case .failure:
                             self.save(completion: completion)
                         }
                     }
-                    
+
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
@@ -186,31 +193,34 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             }
         }
     }
-    
-    public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
+
+    public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
         //Handled with tombstone, marked for deletion
         completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
     }
-    
-    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
-        
+
+    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                              mergeRevision: @escaping (OCKRevisionRecord) -> Void) {
+
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .include([OutcomeKey.values, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
+        query.find(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let outcomes):
-                let pulled = outcomes.compactMap{try? $0.convertToCareKit()}
-                let entities = pulled.compactMap{OCKEntity.outcome($0)}
+                let pulled = outcomes.compactMap {try? $0.convertToCareKit()}
+                let entities = pulled.compactMap {OCKEntity.outcome($0)}
                 let revision = OCKRevisionRecord(entities: entities, knowledgeVector: cloudClock)
                 mergeRevision(revision)
             case .failure(let error):
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: cloudClock)
-                
-                switch error.code{
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                    //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
+
+                switch error.code {
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
+                    //If the query was looking in a column that wasn't a default column,
+                    //it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
@@ -221,25 +231,26 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{private}", log: .outcome, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}",
+                               log: .outcome, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
             }
         }
     }
-    
-    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
-        
+
+    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+
         self.logicalClock = cloudClock //Stamp Entity
-        
+
         guard self.deletedDate != nil else {
-            
+
             self.addToCloud(overwriteRemote: overwriteRemote) { result in
-            
+
                 switch result {
-                
-                case .success(_):
+
+                case .success:
                     completion(nil)
                 case .failure(let error):
                     completion(error)
@@ -247,42 +258,42 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             }
             return
         }
-        
+
         self.tombstone { result in
-            
+
             switch result {
-            
-            case .success(_):
+
+            case .success:
                 completion(nil)
             case .failure(let error):
                 completion(error)
             }
         }
     }
-    
-    public func tombstone(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func tombstone(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-                
+
         //Get latest item from the Cloud to compare against
         let query = Outcome.query(ObjectableKey.uuid == uuid)
             .include([OutcomeKey.values, ObjectableKey.notes])
-        query.first(callbackQueue: .main){ result in
-            
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundObject):
                 //CareKit causes ParseCareKit to create new ones of these, this is removing duplicates
-                foundObject.values?.forEach{
-                    $0.delete(callbackQueue: .main){ _ in }
-                    $0.notes?.forEach{ $0.delete(callbackQueue: .main){ _ in } }
+                foundObject.values?.forEach {
+                    $0.delete(callbackQueue: .main) { _ in }
+                    $0.notes?.forEach { $0.delete(callbackQueue: .main) { _ in } }
                 }
-                foundObject.notes?.forEach{ $0.delete(callbackQueue: .main){ _ in } } //CareKit causes ParseCareKit to create new ones of these, this is removing duplicates
-                
+                foundObject.notes?.forEach { $0.delete(callbackQueue: .main) { _ in } }
+
                 guard let copied = try? Self.copyValues(from: self, to: foundObject) else {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.outcome.debug("tombstone(), Couldn't cast to self")
@@ -293,11 +304,12 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     return
                 }
                 copied.save(completion: completion)
-    
+
             case .failure(let error):
                 switch error.code {
-                
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
+
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
                     self.save(completion: completion)
 
                 default:
@@ -312,33 +324,33 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             }
         }
     }
-    
-    public class func copyValues(from other: Outcome, to here: Outcome) throws -> Self{
+
+    public class func copyValues(from other: Outcome, to here: Outcome) throws -> Self {
         var here = here
         here.copyCommonValues(from: other)
         here.taskOccurrenceIndex = other.taskOccurrenceIndex
         here.values = other.values
         here.task = other.task
-        
+
         guard let copied = here as? Self else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
         return copied
     }
-        
+
     public class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Outcome {
-        
-        guard let outcome = outcomeAny as? OCKOutcome else{
+
+        guard let outcome = outcomeAny as? OCKOutcome else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
-        
+
         let encoded = try ParseCareKitUtility.encoder().encode(outcome)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = outcome.id
         decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
-    
+
     public func copyRelational(_ parse: Outcome) -> Outcome {
         var copy = self
         copy = copy.copyRelationalEntities(parse)
@@ -350,7 +362,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         }
         return copy
     }
-        
+
     public func prepareEncodingRelational(_ encodingForParse: Bool) {
         task?.encodingForParse = encodingForParse
         values?.forEach {
@@ -367,15 +379,15 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcome.self, from: encoded)
     }
-    
-    public func save(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
+
+    public func save(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
         guard let stamped = try? self.stampRelational() else {
             completion(.failure(ParseCareKitError.cantUnwrapSelf))
             return
         }
-        stamped.save(callbackQueue: .main){ results in
+        stamped.save(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let saved):
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.outcome.debug("save(), Object: \(saved.localizedDescription, privacy: .private)")
@@ -384,14 +396,14 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 }
 
                 saved.linkRelated { result in
-                    
+
                     switch result {
-                    
+
                     case .success(let linkedObject):
-                        linkedObject.save(callbackQueue: .main){ _ in }
+                        linkedObject.save(callbackQueue: .main) { _ in }
                         completion(.success(linkedObject))
 
-                    case .failure(_):
+                    case .failure:
                         completion(.success(saved))
                     }
                 }
@@ -405,89 +417,91 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             }
         }
     }
-    
+
     ///Link versions and related classes
-    public func linkRelated(completion: @escaping(Result<Outcome,Error>)->Void){
+    public func linkRelated(completion: @escaping(Result<Outcome, Error>) -> Void) {
         guard let taskUUID = self.taskUUID,
-              let taskOccurrenceIndex = self.taskOccurrenceIndex else{
+              let taskOccurrenceIndex = self.taskOccurrenceIndex else {
             //Finished if there's no Task, otherwise see if it's in the cloud
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         Task.first(taskUUID, relatedObject: self.task) { result in
-            
+
             switch result {
-            
+
             case .success(let foundTask):
-            
+
                 self.task = foundTask
-                
-                guard let currentTask = self.task else{
+
+                guard let currentTask = self.task else {
                     self.date = nil
                     completion(.success(self))
                     return
                 }
-                
+
                 self.date = currentTask.schedule?.event(forOccurrenceIndex: taskOccurrenceIndex)?.start
                 completion(.success(self))
 
-            case .failure(_):
+            case .failure:
                 //We still keep going if the link was unsuccessfull
                 completion(.success(self))
             }
         }
     }
-    
-    public static func tagWithId(_ outcome: OCKOutcome)-> OCKOutcome?{
-        
+
+    public static func tagWithId(_ outcome: OCKOutcome) -> OCKOutcome? {
+
         //If this object has a createdDate, it's been stored locally before
-        guard outcome.uuid != nil else{
+        guard outcome.uuid != nil else {
             return nil
         }
-        
+
         var mutableOutcome = outcome
-       
-        if mutableOutcome.tags != nil{
-            if !mutableOutcome.tags!.contains(mutableOutcome.id){
+
+        if mutableOutcome.tags != nil {
+            if !mutableOutcome.tags!.contains(mutableOutcome.id) {
                 mutableOutcome.tags!.append(mutableOutcome.id)
                 return mutableOutcome
             }
-        }else{
+        } else {
             mutableOutcome.tags = [mutableOutcome.id]
             return mutableOutcome
         }
-        
+
         return nil
     }
-    
+
     public func stampRelational() throws -> Outcome {
         var stamped = self
         stamped = try stamped.stampRelationalEntities()
-        stamped.values?.forEach{$0.stamp(stamped.logicalClock!)}
-        
+        stamped.values?.forEach {$0.stamp(stamped.logicalClock!)}
+
         return stamped
     }
-    
-    public static func queryNotDeleted()-> Query<Outcome>{
+
+    public static func queryNotDeleted()-> Query<Outcome> {
         let taskQuery = Task.query(doesNotExist(key: OutcomeKey.deletedDate))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
-        let query = Outcome.query(doesNotExist(key: OutcomeKey.deletedDate), matchesKeyInQuery(key: OutcomeKey.task, queryKey: OutcomeKey.task, query: taskQuery))
+        let query = Outcome.query(doesNotExist(key: OutcomeKey.deletedDate),
+                                  matchesKeyInQuery(key: OutcomeKey.task,
+                                                    queryKey: OutcomeKey.task, query: taskQuery))
             .include([OutcomeKey.values, ObjectableKey.notes])
         return query
     }
-   
+
     func findOutcomes() throws -> [Outcome] {
         let query = Self.queryNotDeleted()
         return try query.find()
     }
-    
-    public func findOutcomesInBackground(completion: @escaping([Outcome]?,Error?)->Void) {
+
+    public func findOutcomesInBackground(completion: @escaping([Outcome]?, Error?) -> Void) {
         let query = Self.queryNotDeleted()
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let entities):
                 completion(entities, nil)
             case .failure(let error):
@@ -514,4 +528,4 @@ extension Outcome {
         try encodeObjectable(to: encoder)
         encodingForParse = true
     }
-}
+}// swiftlint:disable:this file_length

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -29,8 +29,6 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     
     public internal(set) var updatedDate: Date?
     
-    public internal(set) var deletedDate: Date?
-    
     public var timezone: TimeZone?
     
     public var userInfo: [String : String]?
@@ -63,6 +61,10 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     
     var date: Date? //Custom added, check if needed
     
+    /// The date on which this object was tombstoned. Note that objects are never actually deleted,
+    /// but rather they are tombstoned and will no longer be returned from queries.
+    public internal(set) var deletedDate: Date?
+    
     /// Specifies how many events occured before this outcome was created. For example, if a task is schedule to happen twice per day, then
     /// the 2nd outcome on the 2nd day will have a `taskOccurrenceIndex` of 3.
     ///
@@ -91,6 +93,11 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 task = nil
             }
         }
+    }
+
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) taskOccurrenceIndex=\(String(describing: taskOccurrenceIndex)) values=\(String(describing: values)) taskUUID=\(String(describing: taskUUID)) task=\(String(describing: task)) date=\(String(describing: date)) deletedDate=\(String(describing: deletedDate))"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -370,9 +377,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             
             case .success(let saved):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.outcome.debug("save(), Object: \(saved, privacy: .private)")
+                    Logger.outcome.debug("save(), Object: \(saved.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("save(), Object: %{private}", log: .outcome, type: .debug, saved.description)
+                    os_log("save(), Object: %{private}", log: .outcome, type: .debug, saved.localizedDescription)
                 }
 
                 saved.linkRelated { result in

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -19,7 +19,7 @@ import os.log
 /// For example, a task that asks a patient to measure their temperature will have events whose outcome
 /// will contain a single value representing the patient's temperature.
 // swiftlint:disable:next type_body_length
-final public class Outcome: PCKObjectable, PCKSynchronizable {
+open class Outcome: PCKObjectable, PCKSynchronizable {
 
     public var uuid: UUID?
 
@@ -111,7 +111,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         case task, taskUUID, taskOccurrenceIndex, values, deletedDate, date
     }
 
-    public func new(with careKitEntity: OCKEntity) throws -> Outcome {
+    public func new(with careKitEntity: OCKEntity) throws -> Self {
 
         switch careKitEntity {
         case .outcome(let entity):
@@ -338,7 +338,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         return copied
     }
 
-    public class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Outcome {
+    public class func copyCareKit(_ outcomeAny: OCKAnyOutcome) throws -> Self {
 
         guard let outcome = outcomeAny as? OCKOutcome else {
             throw ParseCareKitError.cantCastToNeededClassType

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -106,9 +106,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             return try Self.copyCareKit(entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.outcome.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.outcome.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .outcome, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .outcome, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
@@ -170,9 +170,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.outcome.error("addToCloud(), \(error.localizedDescription)")
+                        Logger.outcome.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("addToCloud(), %{public}@", log: .outcome, type: .error, error.localizedDescription)
+                        os_log("addToCloud(), %{private}@", log: .outcome, type: .error, error.localizedDescription)
                     }
                     completion(.failure(error))
                 }
@@ -206,15 +206,15 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                        Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .outcome, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .outcome, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.outcome.debug("An unexpected error occured \(error.localizedDescription)")
+                        Logger.outcome.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{public}", log: .outcome, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}", log: .outcome, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
@@ -296,9 +296,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.outcome.error("updateCloud(), \(error.localizedDescription)")
+                        Logger.outcome.error("updateCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("updateCloud(), %{public}", log: .outcome, type: .error, error.localizedDescription)
+                        os_log("updateCloud(), %{private}", log: .outcome, type: .error, error.localizedDescription)
                     }
                     completion(.failure(error))
                 }
@@ -389,9 +389,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                 }
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.outcome.error("save(), \(error.localizedDescription)")
+                    Logger.outcome.error("save(), \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("save(), %{public}", log: .outcome, type: .error, error.localizedDescription)
+                    os_log("save(), %{private}", log: .outcome, type: .error, error.localizedDescription)
                 }
                 completion(.failure(error))
             }

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -57,7 +57,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
     var date: Date? //Custom added, check if needed
     
@@ -335,6 +335,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         let encoded = try ParseCareKitUtility.encoder().encode(outcome)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = outcome.id
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
     

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -21,17 +21,17 @@ import os.log
 // swiftlint:disable:next type_body_length
 final public class Outcome: PCKObjectable, PCKSynchronizable {
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -49,7 +49,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
@@ -67,7 +67,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
 
     /// The date on which this object was tombstoned. Note that objects are never actually deleted,
     /// but rather they are tombstoned and will no longer be returned from queries.
-    public internal(set) var deletedDate: Date?
+    public var deletedDate: Date?
 
     /// Specifies how many events occured before this outcome was created. For example, if a task is schedule to happen twice per day, then
     /// the 2nd outcome on the 2nd day will have a `taskOccurrenceIndex` of 3.

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -130,7 +130,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         }
         
         //Check to see if already in the cloud
-        let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
+        let query = Outcome.query(ObjectableKey.uuid == uuid)
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -158,8 +158,8 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     guard self.id.count > 0 else {
                         return
                     }
-                    let query = Outcome.query(kPCKObjectableEntityIdKey == self.id, doesNotExist(key: kPCKObjectableDeletedDateKey))
-                        .include([kPCKOutcomeValuesKey, kPCKObjectableNotesKey])
+                    let query = Outcome.query(ObjectableKey.entityId == self.id, doesNotExist(key: OutcomeKey.deletedDate))
+                        .include([OutcomeKey.values, ObjectableKey.notes])
                     query.first(callbackQueue: .main){ result in
                         
                         switch result {
@@ -194,9 +194,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     
     public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
-        let query = Self.query(kPCKObjectableClockKey >= localClock)
-            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKOutcomeValuesKey, kPCKObjectableNotesKey])
+        let query = Self.query(ObjectableKey.logicalClock >= localClock)
+            .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
+            .include([OutcomeKey.values, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             switch results {
             
@@ -213,9 +213,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
+                        Logger.outcome.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .outcome, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .outcome, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
@@ -269,8 +269,8 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
         }
                 
         //Get latest item from the Cloud to compare against
-        let query = Outcome.query(kPCKObjectableUUIDKey == uuid)
-            .include([kPCKOutcomeValuesKey, kPCKObjectableNotesKey])
+        let query = Outcome.query(ObjectableKey.uuid == uuid)
+            .include([OutcomeKey.values, ObjectableKey.notes])
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -470,10 +470,10 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     }
     
     public static func queryNotDeleted()-> Query<Outcome>{
-        let taskQuery = Task.query(doesNotExist(key: kPCKObjectableDeletedDateKey))
+        let taskQuery = Task.query(doesNotExist(key: OutcomeKey.deletedDate))
         // **** BAKER need to fix matchesKeyInQuery and find equivalent "queryKey" in matchesQuery
-        let query = Outcome.query(doesNotExist(key: kPCKObjectableDeletedDateKey), matchesKeyInQuery(key: kPCKOutcomeTaskKey, queryKey: kPCKOutcomeTaskKey, query: taskQuery))
-            .include([kPCKOutcomeValuesKey, kPCKObjectableNotesKey])
+        let query = Outcome.query(doesNotExist(key: OutcomeKey.deletedDate), matchesKeyInQuery(key: OutcomeKey.task, queryKey: OutcomeKey.task, query: taskQuery))
+            .include([OutcomeKey.values, ObjectableKey.notes])
         return query
     }
    

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -370,9 +370,9 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
             
             case .success(let saved):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.outcome.debug("save(), Saved: \(saved, privacy: .private)")
+                    Logger.outcome.debug("save(), Object: \(saved, privacy: .private)")
                 } else {
-                    os_log("save(), Saved: %{private}", log: .outcome, type: .debug, saved.description)
+                    os_log("save(), Object: %{private}", log: .outcome, type: .debug, saved.description)
                 }
 
                 saved.linkRelated { result in

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -354,7 +354,7 @@ final public class Outcome: PCKObjectable, PCKSynchronizable {
     }
 
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcome {
+    public func convertToCareKit() throws -> OCKOutcome {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcome.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -465,13 +465,14 @@ extension Outcome {
         }
         try container.encodeIfPresent(taskUUID, forKey: .taskUUID)
         try container.encodeIfPresent(taskOccurrenceIndex, forKey: .taskOccurrenceIndex)
-        guard let valuesToEncode = values else {
+        try container.encodeIfPresent(values, forKey: .values)
+        /*guard let valuesToEncode = values else {
             throw ParseCareKitError.requiredValueCantBeUnwrapped
         }
         try valuesToEncode.forEach { value in
             var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .values)
             try nestedUnkeyedContainer.encode(value)
-        }
+        }*/
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         if id.count > 0 {
             entityId = id

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -17,7 +17,7 @@ import CareKitStore
 /// `OCKOutcomeValue` is a representation of any response of measurement that a user gives
 /// in response to a task. The underlying type could be any of a number of types including
 /// integers, booleans, dates, text, and binary data, among others.
-final public class OutcomeValue: PCKObjectable {
+open class OutcomeValue: PCKObjectable {
 
     public var uuid: UUID?
 
@@ -116,7 +116,7 @@ final public class OutcomeValue: PCKObjectable {
     }
 
     // swiftlint:disable:next function_body_length
-    public init(from decoder: Decoder) throws {
+    required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         //Decode Parse first

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -19,17 +19,17 @@ import CareKitStore
 /// integers, booleans, dates, text, and binary data, among others.
 final public class OutcomeValue: PCKObjectable {
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -47,7 +47,7 @@ final public class OutcomeValue: PCKObjectable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -188,7 +188,7 @@ final public class OutcomeValue: PCKObjectable {
         return decoded
     }
     
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKOutcomeValue {
+    public func convertToCareKit() throws -> OCKOutcomeValue {
         encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcomeValue.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -98,7 +98,12 @@ final public class OutcomeValue: PCKObjectable {
         if value is Date { return .date }
         fatalError("Unknown type!")
     }
-    
+
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) value=\(String(describing: value)) kind=\(String(describing: kind)) units=\(String(describing: units)) index=\(String(describing: index))"
+    }
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -10,63 +10,67 @@ import Foundation
 import ParseSwift
 import CareKitStore
 
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable line_length
+
 /// An `OutcomeValue` is the ParseCareKit equivalent of `OCKOutcomeValue`.  An
 /// `OCKOutcomeValue` is a representation of any response of measurement that a user gives
 /// in response to a task. The underlying type could be any of a number of types including
 /// integers, booleans, dates, text, and binary data, among others.
 final public class OutcomeValue: PCKObjectable {
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
+
     /// The index can be used to track the order or arrangement of outcomes values, when relevant.
-    public var index:Int?
-    
-    /// An optional property that can be used to specify what kind of value this is (e.g. blood pressure, qualitative stress, weight)
-    public var kind:String?
-    
+    public var index: Int?
+
+    /// An optional property that can be used to specify what kind of
+    /// value this is (e.g. blood pressure, qualitative stress, weight)
+    public var kind: String?
+
     /// The units for this measurement.
-    public var units:String?
-    
+    public var units: String?
+
     /// The underlying value.
     public var value: OCKOutcomeValueUnderlyingType?
 
@@ -87,7 +91,7 @@ final public class OutcomeValue: PCKObjectable {
 
     /// The underlying value as a date.
     var dateValue: Date? { return value as? Date }
-    
+
     /// Holds information about the type of this value.
     public var type: OCKOutcomeValueType {
         if value is Int { return .integer }
@@ -106,18 +110,20 @@ final public class OutcomeValue: PCKObjectable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case uuid, schemaVersion, createdDate, updatedDate, timezone, userInfo,
+             groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case index, kind, units, value, type
     }
 
+    // swiftlint:disable:next function_body_length
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        
+
         //Decode Parse first
         objectId = try container.decodeIfPresent(String.self, forKey: .objectId)
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
         updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
-        
+
         guard let valueType = try container.decodeIfPresent(OCKOutcomeValueType.self, forKey: .type) else {
             return
         }
@@ -154,7 +160,7 @@ final public class OutcomeValue: PCKObjectable {
                 value = try container.decode(Date.self, forKey: .value)
             }
         }
-        
+
         kind = try container.decodeIfPresent(String.self, forKey: .kind)
         units = try container.decodeIfPresent(String.self, forKey: .units)
         index = try container.decodeIfPresent(Int.self, forKey: .index)
@@ -180,42 +186,42 @@ final public class OutcomeValue: PCKObjectable {
         here.kind = other.kind
         here.units = other.units
         here.value = other.value
-       
+
         guard let copied = here as? Self else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
         return copied
     }
-    
+
     public class func copyCareKit(_ outcomeValue: OCKOutcomeValue) throws -> OutcomeValue {
         let encoded = try ParseCareKitUtility.encoder().encode(outcomeValue)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
-    
+
     public func convertToCareKit() throws -> OCKOutcomeValue {
         encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKOutcomeValue.self, from: encoded)
     }
-    
+
     public func prepareEncodingRelational(_ encodingForParse: Bool) {
         notes?.forEach {
             $0.encodingForParse = encodingForParse
         }
     }
 
-    func stamp(_ clock: Int){
+    func stamp(_ clock: Int) {
         self.logicalClock = clock
-        self.notes?.forEach{
+        self.notes?.forEach {
             $0.logicalClock = self.logicalClock
         }
     }
-    
-    public class func replaceWithCloudVersion(_ local:inout [OutcomeValue], cloud:[OutcomeValue]){
-        for (index,value) in local.enumerated(){
-            guard let cloudNote = cloud.first(where: {$0.uuid == value.uuid}) else{
+
+    public class func replaceWithCloudVersion(_ local:inout [OutcomeValue], cloud: [OutcomeValue]) {
+        for (index, value) in local.enumerated() {
+            guard let cloudNote = cloud.first(where: {$0.uuid == value.uuid}) else {
                 continue
             }
             local[index] = cloudNote
@@ -255,7 +261,8 @@ extension OutcomeValue {
 
             guard encodedValue else {
                 let message = "Value could not be converted to a concrete type."
-                throw EncodingError.invalidValue(value ?? "", EncodingError.Context(codingPath: [CodingKeys.value], debugDescription: message))
+                throw EncodingError.invalidValue(value ?? "",
+                                                 EncodingError.Context(codingPath: [CodingKeys.value], debugDescription: message))
             }
         }
         try self.encodeObjectable(to: encoder)

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -56,7 +56,7 @@ final public class OutcomeValue: PCKObjectable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
     /// The index can be used to track the order or arrangement of outcomes values, when relevant.
     public var index:Int?
@@ -190,6 +190,7 @@ final public class OutcomeValue: PCKObjectable {
     public class func copyCareKit(_ outcomeValue: OCKOutcomeValue) throws -> OutcomeValue {
         let encoded = try ParseCareKitUtility.encoder().encode(outcomeValue)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
     

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -124,7 +124,7 @@ public final class Patient: PCKVersionable {
         case .patient(let entity):
             return try Self.copyCareKit(entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.patient.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .patient, type: .error, careKitEntity.entityType.debugDescription)
@@ -167,7 +167,7 @@ public final class Patient: PCKVersionable {
                     self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.error("addToCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("addToCloud(), %{public}@", log: .patient, type: .error, error.localizedDescription)
@@ -197,7 +197,7 @@ public final class Patient: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
                     } else {
                         os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .patient, type: .debug)
@@ -206,7 +206,7 @@ public final class Patient: PCKVersionable {
                 case 1:
                     //This is the typical case
                     guard let previousVersion = foundObjects.first(where: {$0.uuid == previousVersionUUID}) else {
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.patient.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
                             os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .patient, type: .error, previousVersionUUID.uuidString)
@@ -219,7 +219,7 @@ public final class Patient: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
                         os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .patient, type: .error, uuid.uuidString)
@@ -227,7 +227,7 @@ public final class Patient: PCKVersionable {
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.patient.error("updateCloud(), \(error.localizedDescription)")
                 } else {
                     os_log("updateCloud(), %{public}", log: .patient, type: .error, error.localizedDescription)
@@ -257,13 +257,13 @@ public final class Patient: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
                     } else {
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .patient, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.debug("An unexpected error occured \(error.localizedDescription)")
                     } else {
                         os_log("An unexpected error occured \"%{public}", log: .patient, type: .debug, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -144,7 +144,7 @@ public final class Patient: PCKVersionable {
         }
 
         //Check to see if already in the cloud
-        let query = Self.query(kPCKObjectableUUIDKey == uuid)
+        let query = Self.query(ObjectableKey.uuid == uuid)
         query.first(callbackQueue: .main){ result in
            
             switch result {
@@ -191,8 +191,8 @@ public final class Patient: PCKVersionable {
         }
         
         //Check to see if this entity is already in the Cloud, but not paired locally
-        let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Patient.query(containedIn(key: ObjectableKey.uuid, array: [uuid,previousVersionUUID]))
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -242,9 +242,9 @@ public final class Patient: PCKVersionable {
     
     public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
-        let query = Self.query(kPCKObjectableClockKey >= localClock)
-            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Self.query(ObjectableKey.logicalClock >= localClock)
+            .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             switch results {
             
@@ -261,9 +261,9 @@ public final class Patient: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
+                        Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .patient, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .patient, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -11,6 +11,10 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable type_body_length
+// swiftlint:disable line_length
+
 /// An `Patient` is the ParseCareKit equivalent of `OCKPatient`.  An `OCKPatient` represents a patient.
 public final class Patient: PCKVersionable {
     public internal(set) var nextVersion: Patient? {
@@ -18,8 +22,8 @@ public final class Patient: PCKVersionable {
             nextVersionUUID = nextVersion?.uuid
         }
     }
-    
-    public internal(set) var nextVersionUUID:UUID? {
+
+    public internal(set) var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -32,7 +36,7 @@ public final class Patient: PCKVersionable {
             previousVersionUUID = previousVersion?.uuid
         }
     }
-    
+
     public internal(set) var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
@@ -40,77 +44,77 @@ public final class Patient: PCKVersionable {
             }
         }
     }
-    
+
     public var effectiveDate: Date?
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public internal(set) var deletedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
+
     public var objectId: String?
-    
+
     public var createdAt: Date?
-    
+
     public var updatedAt: Date?
-    
+
     public var ACL: ParseACL?
-    
+
     /// A list of substances this patient is allergic to.
-    public var allergies:[String]?
+    public var allergies: [String]?
 
     /// The patient's birthday, used to compute their age.
-    public var birthday:Date?
-    
+    public var birthday: Date?
+
     /// The patient's name.
     public var name: PersonNameComponents?
-    
+
     /// The patient's biological sex.
     public var sex: OCKBiologicalSex?
-    
+
     /// A textual representation of this instance, suitable for debugging.
     public var localizedDescription: String {
         "\(debugDescription) name=\(String(describing: name)) birthday=\(String(describing: birthday)) sex=\(String(describing: sex)) allergies=\(String(describing: allergies))"
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUID, nextVersionUUID, previousVersion, nextVersion, effectiveDate
         case allergies, birthday, name, sex
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(allergies, forKey: .allergies)
@@ -120,9 +124,9 @@ public final class Patient: PCKVersionable {
         try encodeVersionable(to: encoder)
         encodingForParse = true
     }
-    
+
     public func new(with careKitEntity: OCKEntity) throws -> Patient {
-    
+
         switch careKitEntity {
         case .patient(let entity):
             return try Self.copyCareKit(entity)
@@ -135,27 +139,27 @@ public final class Patient: PCKVersionable {
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
-    
-    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
 
         //Check to see if already in the cloud
         let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: .main){ result in
-           
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundEntity):
                 guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                     return
                 }
-                
+
                 if overwriteRemote {
                     self.updateCloud(completion: completion)
                 } else {
@@ -164,8 +168,8 @@ public final class Patient: PCKVersionable {
                 }
 
             case .failure(let error):
-                
-                switch error.code{
+
+                switch error.code {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     self.save(completion: completion)
                 default:
@@ -181,24 +185,24 @@ public final class Patient: PCKVersionable {
             }
         }
     }
-    
-    public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
+
+    public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
               let uuid = self.uuid,
-            let previousVersionUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if this entity is already in the Cloud, but not paired locally
-        let query = Patient.query(containedIn(key: ObjectableKey.uuid, array: [uuid,previousVersionUUID]))
+        let query = Patient.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let foundObjects):
-                switch foundObjects.count{
+                switch foundObjects.count {
                 case 0:
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.patient.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
@@ -239,54 +243,60 @@ public final class Patient: PCKVersionable {
             }
         }
     }
-    
-    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
-        
+
+    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void) {
+
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
+        query.find(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let carePlans):
-                let pulled = carePlans.compactMap{try? $0.convertToCareKit()}
-                let entities = pulled.compactMap{OCKEntity.patient($0)}
+                let pulled = carePlans.compactMap {try? $0.convertToCareKit()}
+                let entities = pulled.compactMap {OCKEntity.patient($0)}
                 let revision = OCKRevisionRecord(entities: entities, knowledgeVector: cloudClock)
                 mergeRevision(revision)
             case .failure(let error):
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: cloudClock)
-                
-                switch error.code{
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                    //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
+
+                switch error.code {
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
+                    //If the query was looking in a column that wasn't a default column,
+                    //it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
+                        // swiftlint:disable:next line_length
                         Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
+                        // swiftlint:disable:next line_length
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .patient, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
+                        // swiftlint:disable:next line_length
                         Logger.patient.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{private}", log: .patient, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}",
+                               log: .patient, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
             }
         }
     }
-    
-    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
-        
+
+    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+
         self.logicalClock = cloudClock //Stamp Entity
-        
-        guard let _ = self.previousVersionUUID else{
+
+        guard self.previousVersionUUID != nil else {
             self.addToCloud(overwriteRemote: false) { result in
-                
+
                 switch result {
-                
-                case .success(_):
+
+                case .success:
                     completion(nil)
                 case .failure(let error):
                     completion(error)
@@ -294,19 +304,19 @@ public final class Patient: PCKVersionable {
             }
             return
         }
-        
+
         self.updateCloud { result in
-            
+
             switch result {
-            
-            case .success(_):
+
+            case .success:
                 completion(nil)
             case .failure(let error):
                 completion(error)
             }
         }
     }
-    
+
     public class func copyValues(from other: Patient, to here: Patient) throws -> Self {
         var here = here
         here.copyVersionedValues(from: other)
@@ -319,13 +329,13 @@ public final class Patient: PCKVersionable {
         }
         return copied
     }
-    
+
     public class func copyCareKit(_ patientAny: OCKAnyPatient) throws -> Patient {
-        
-        guard let patient = patientAny as? OCKPatient else{
+
+        guard let patient = patientAny as? OCKPatient else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
-        
+
         let encoded = try ParseCareKitUtility.encoder().encode(patient)
         let decoded = try ParseCareKitUtility.decoder().decode(Patient.self, from: encoded)
         decoded.entityId = patient.id
@@ -340,7 +350,7 @@ public final class Patient: PCKVersionable {
             $0.encodingForParse = encodingForParse
         }
     }
-    
+
     public func convertToCareKit() throws -> OCKPatient {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -85,7 +85,7 @@ public final class Patient: PCKVersionable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
     /// A list of substances this patient is allergic to.
     public var allergies:[String]?
@@ -329,6 +329,7 @@ public final class Patient: PCKVersionable {
         let encoded = try ParseCareKitUtility.encoder().encode(patient)
         let decoded = try ParseCareKitUtility.decoder().decode(Patient.self, from: encoded)
         decoded.entityId = patient.id
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -17,13 +17,13 @@ import os.log
 
 /// An `Patient` is the ParseCareKit equivalent of `OCKPatient`.  An `OCKPatient` represents a patient.
 public final class Patient: PCKVersionable {
-    public internal(set) var nextVersion: Patient? {
+    public var nextVersion: Patient? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
 
-    public internal(set) var nextVersionUUID: UUID? {
+    public var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -31,13 +31,13 @@ public final class Patient: PCKVersionable {
         }
     }
 
-    public internal(set) var previousVersion: Patient? {
+    public var previousVersion: Patient? {
         didSet {
             previousVersionUUID = previousVersion?.uuid
         }
     }
 
-    public internal(set) var previousVersionUUID: UUID? {
+    public var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
                 previousVersion = nil
@@ -47,19 +47,19 @@ public final class Patient: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
-    public internal(set) var deletedDate: Date?
+    public var deletedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -77,7 +77,7 @@ public final class Patient: PCKVersionable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -125,9 +125,9 @@ public final class Patient: PCKVersionable {
             return try Self.copyCareKit(entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.patient.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.patient.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .patient, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .patient, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
@@ -168,9 +168,9 @@ public final class Patient: PCKVersionable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.patient.error("addToCloud(), \(error.localizedDescription)")
+                        Logger.patient.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("addToCloud(), %{public}@", log: .patient, type: .error, error.localizedDescription)
+                        os_log("addToCloud(), %{private}@", log: .patient, type: .error, error.localizedDescription)
                     }
                     completion(.failure(error))
                 }
@@ -228,9 +228,9 @@ public final class Patient: PCKVersionable {
                 }
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.patient.error("updateCloud(), \(error.localizedDescription)")
+                    Logger.patient.error("updateCloud(), \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("updateCloud(), %{public}", log: .patient, type: .error, error.localizedDescription)
+                    os_log("updateCloud(), %{private}", log: .patient, type: .error, error.localizedDescription)
                 }
                 completion(.failure(error))
             }
@@ -258,15 +258,15 @@ public final class Patient: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                        Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .patient, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .patient, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.patient.debug("An unexpected error occured \(error.localizedDescription)")
+                        Logger.patient.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{public}", log: .patient, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}", log: .patient, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ParseSwift
 import CareKitStore
+import os.log
 
 /// An `Patient` is the ParseCareKit equivalent of `OCKPatient`.  An `OCKPatient` represents a patient.
 public final class Patient: PCKVersionable {
@@ -123,7 +124,11 @@ public final class Patient: PCKVersionable {
         case .patient(let entity):
             return try Self.copyCareKit(entity)
         default:
-            print("Error in \(className).new(with:). The wrong type of entity was passed \(careKitEntity)")
+            if #available(iOS 14.0, *) {
+                Logger.patient.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+            } else {
+                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .patient, type: .error, careKitEntity.entityType.debugDescription)
+            }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
@@ -162,7 +167,11 @@ public final class Patient: PCKVersionable {
                     self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    print("Error in \(self.className).addToCloud(). \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.patient.error("addToCloud(), \(error.localizedDescription)")
+                    } else {
+                        os_log("addToCloud(), %{public}@", log: .patient, type: .error, error.localizedDescription)
+                    }
                     completion(.failure(error))
                 }
                 return
@@ -173,13 +182,13 @@ public final class Patient: PCKVersionable {
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
         guard let _ = PCKUser.current,
               let uuid = self.uuid,
-            let previousPatientUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else{
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
         
         //Check to see if this entity is already in the Cloud, but not paired locally
-        let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousPatientUUID]))
+        let query = Patient.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid,previousVersionUUID]))
             .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
         query.find(callbackQueue: .main){ results in
             
@@ -188,12 +197,20 @@ public final class Patient: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    print("Warning in \(self.className).updateCloud(). A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
+                    if #available(iOS 14.0, *) {
+                        Logger.patient.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
+                    } else {
+                        os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .patient, type: .debug)
+                    }
                     self.addToCloud(overwriteRemote: false, completion: completion)
                 case 1:
                     //This is the typical case
-                    guard let previousVersion = foundObjects.first(where: {$0.uuid == previousPatientUUID}) else {
-                        print("Error in \(self.className).updateCloud(). Didn't find previousVersion and this UUID already exists in Cloud")
+                    guard let previousVersion = foundObjects.first(where: {$0.uuid == previousVersionUUID}) else {
+                        if #available(iOS 14.0, *) {
+                            Logger.patient.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
+                        } else {
+                            os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .patient, type: .error, previousVersionUUID.uuidString)
+                        }
                         completion(.failure(ParseCareKitError.uuidAlreadyExists))
                         return
                     }
@@ -202,11 +219,19 @@ public final class Patient: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    print("Error in \(self.className).updateCloud(). UUID already exists in Cloud")
+                    if #available(iOS 14.0, *) {
+                        Logger.patient.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
+                    } else {
+                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .patient, type: .error, uuid.uuidString)
+                    }
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                print("Error in \(self.className).updateCloud(). \(error.localizedDescription)")
+                if #available(iOS 14.0, *) {
+                    Logger.patient.error("updateCloud(), \(error.localizedDescription)")
+                } else {
+                    os_log("updateCloud(), %{public}", log: .patient, type: .error, error.localizedDescription)
+                }
                 completion(.failure(error))
             }
         }
@@ -232,9 +257,17 @@ public final class Patient: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    print("Warning, table CarePlan either doesn't exist or is missing the column \(kPCKObjectableClockKey). It should be fixed during the first sync of an Outcome... \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.patient.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                    } else {
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .patient, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                    }
                 default:
-                    print("An unexpected error occured \(error.localizedDescription)")
+                    if #available(iOS 14.0, *) {
+                        Logger.patient.debug("An unexpected error occured \(error.localizedDescription)")
+                    } else {
+                        os_log("An unexpected error occured \"%{public}", log: .patient, type: .debug, error.localizedDescription)
+                    }
                 }
                 mergeRevision(revision)
             }

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -337,7 +337,7 @@ public final class Patient: PCKVersionable {
         }
     }
     
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKPatient {
+    public func convertToCareKit() throws -> OCKPatient {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKPatient.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -89,6 +89,8 @@ public final class Patient: PCKVersionable {
     
     /// A list of substances this patient is allergic to.
     public var allergies:[String]?
+
+    /// The patient's birthday, used to compute their age.
     public var birthday:Date?
     
     /// The patient's name.
@@ -97,8 +99,9 @@ public final class Patient: PCKVersionable {
     /// The patient's biological sex.
     public var sex: OCKBiologicalSex?
     
-    public static var className: String {
-        kPCKPatientClassKey
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) name=\(String(describing: name)) birthday=\(String(describing: birthday)) sex=\(String(describing: sex)) allergies=\(String(describing: allergies))"
     }
     
     enum CodingKeys: String, CodingKey {

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -11,10 +11,16 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable line_length
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
+
 /// An `Task` is the ParseCareKit equivalent of `OCKTask`.  An `OCKTask` represents some task or action that a
-/// patient is supposed to perform. Tasks are optionally associable with an `OCKCarePlan`
-/// and must have a unique id and schedule. The schedule determines when and how often the task should be performed, and the
-/// `impactsAdherence` flag may be used to specify whether or not the patients adherence to this task will affect their daily completion rings.
+/// patient is supposed to perform. Tasks are optionally associable with an `OCKCarePlan` and must have a unique
+/// id and schedule. The schedule determines when and how often the task should be performed, and the
+/// `impactsAdherence` flag may be used to specify whether or not the patients adherence to this task will affect
+/// their daily completion rings.
 public final class Task: PCKVersionable {
 
     public internal(set) var nextVersion: Task? {
@@ -22,8 +28,8 @@ public final class Task: PCKVersionable {
             nextVersionUUID = nextVersion?.uuid
         }
     }
-    
-    public internal(set) var nextVersionUUID:UUID? {
+
+    public internal(set) var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -36,7 +42,7 @@ public final class Task: PCKVersionable {
             previousVersionUUID = previousVersion?.uuid
         }
     }
-    
+
     public internal(set) var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
@@ -44,68 +50,67 @@ public final class Task: PCKVersionable {
             }
         }
     }
-    
+
     public var effectiveDate: Date?
-    
+
     public internal(set) var uuid: UUID?
-    
+
     var entityId: String?
-    
+
     public internal(set) var logicalClock: Int?
-    
+
     public internal(set) var schemaVersion: OCKSemanticVersion?
-    
+
     public internal(set) var createdDate: Date?
-    
+
     public internal(set) var updatedDate: Date?
-    
+
     public internal(set) var deletedDate: Date?
-    
+
     public var timezone: TimeZone?
-    
-    public var userInfo: [String : String]?
-    
+
+    public var userInfo: [String: String]?
+
     public var groupIdentifier: String?
-    
+
     public var tags: [String]?
-    
+
     public var source: String?
-    
+
     public var asset: String?
-    
+
     public var notes: [Note]?
-    
+
     public var remoteID: String?
-    
+
     var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
     }
-    
-    public var objectId: String?
-    
-    public var createdAt: Date?
-    
-    public var updatedAt: Date?
-    
-    public var ACL: ParseACL?
-    
 
-    public var impactsAdherence:Bool?
-    public var instructions:String?
-    public var title:String?
+    public var objectId: String?
+
+    public var createdAt: Date?
+
+    public var updatedAt: Date?
+
+    public var ACL: ParseACL?
+
+    public var impactsAdherence: Bool?
+    public var instructions: String?
+    public var title: String?
     public var schedule: OCKSchedule?
-    
+
     /// The care plan to which this task belongs.
-    public var carePlan:CarePlan? {
+    public var carePlan: CarePlan? {
         didSet {
             carePlanUUID = carePlan?.uuid
         }
     }
-    
+
     /// The UUID of the care plan to which this task belongs.
-    public var carePlanUUID:UUID? {
+    public var carePlanUUID: UUID? {
         didSet {
             if carePlanUUID != carePlan?.uuid {
                 carePlan = nil
@@ -124,9 +129,9 @@ public final class Task: PCKVersionable {
         case previousVersionUUID, nextVersionUUID, previousVersion, nextVersion, effectiveDate
         case title, carePlan, carePlanUUID, impactsAdherence, instructions, schedule
     }
-    
+
     public func new(with careKitEntity: OCKEntity) throws -> Task {
-        
+
         switch careKitEntity {
         case .task(let entity):
             return try Self.copyCareKit(entity)
@@ -139,27 +144,27 @@ public final class Task: PCKVersionable {
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
     }
-    
-    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
-              let uuid = self.uuid else{
+
+    public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
+              let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if already in the cloud
         let query = Task.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: .main){ result in
-            
+        query.first(callbackQueue: .main) { result in
+
             switch result {
-            
+
             case .success(let foundEntity):
                 guard foundEntity.entityId == self.entityId else {
                     //This object has a duplicate uuid but isn't the same object
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                     return
                 }
-                
+
                 if overwriteRemote {
                     self.updateCloud(completion: completion)
                 } else {
@@ -169,8 +174,9 @@ public final class Task: PCKVersionable {
 
             case .failure(let error):
                 switch error.code {
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                        self.save(completion: completion)
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
+                    self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
@@ -184,24 +190,24 @@ public final class Task: PCKVersionable {
             }
         }
     }
-    
-    public func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void){
-        guard let _ = PCKUser.current,
+
+    public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
+        guard PCKUser.current != nil,
               let uuid = self.uuid,
-            let previousVersionUUID = self.previousVersionUUID else{
+            let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
-        
+
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Task.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
             .include([TaskKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let foundObjects):
-                switch foundObjects.count{
+                switch foundObjects.count {
                 case 0:
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
@@ -228,7 +234,8 @@ public final class Task: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
-                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .task, type: .error, uuid.uuidString)
+                        os_log("updateCloud(), UUID (%{private}) already exists in Cloud",
+                               log: .task, type: .error, uuid.uuidString)
                     }
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
@@ -242,26 +249,29 @@ public final class Task: PCKVersionable {
             }
         }
     }
-    
-    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
-        
+
+    public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                              mergeRevision: @escaping (OCKRevisionRecord) -> Void) {
+
         let query = Task.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
-        query.find(callbackQueue: .main){ results in
+        query.find(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let tasks):
-                let pulled = tasks.compactMap{try? $0.convertToCareKit()}
-                let entities = pulled.compactMap{OCKEntity.task($0)}
+                let pulled = tasks.compactMap {try? $0.convertToCareKit()}
+                let entities = pulled.compactMap {OCKEntity.task($0)}
                 let revision = OCKRevisionRecord(entities: entities, knowledgeVector: cloudClock)
                 mergeRevision(revision)
             case .failure(let error):
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: cloudClock)
-                
-                switch error.code{
-                case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                    //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
+
+                switch error.code {
+                case .internalServer, .objectNotFound:
+                    //1 - this column hasn't been added. 101 - Query returned no results
+                    //If the query was looking in a column that wasn't a default column,
+                    //it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
@@ -272,24 +282,25 @@ public final class Task: PCKVersionable {
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{private}", log: .task, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}",
+                               log: .task, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)
             }
         }
     }
-    
-    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
-        
+
+    public func pushRevision(cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+
         self.logicalClock = cloudClock //Stamp Entity
-        
-        guard let _ = self.previousVersionUUID else {
+
+        guard self.previousVersionUUID != nil else {
             self.addToCloud(overwriteRemote: overwriteRemote) { result in
-                
+
                 switch result {
-                
-                case .success(_):
+
+                case .success:
                     completion(nil)
                 case .failure(let error):
                     completion(error)
@@ -297,43 +308,42 @@ public final class Task: PCKVersionable {
             }
             return
         }
-        
+
         self.updateCloud { result in
-            
+
             switch result {
-            
-            case .success(_):
+
+            case .success:
                 completion(nil)
             case .failure(let error):
                 completion(error)
             }
         }
     }
-    
+
     public class func copyValues(from other: Task, to here: Task) throws -> Task {
         var here = here
         here.copyVersionedValues(from: other)
-        
+
         here.impactsAdherence = other.impactsAdherence
         here.instructions = other.instructions
         here.title = other.title
         here.schedule = other.schedule
         here.carePlan = other.carePlan
         here.carePlanUUID = other.carePlanUUID
-        
+
         guard let copied = here as? Self else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
         return copied
     }
-    
-    
+
     public class func copyCareKit(_ taskAny: OCKAnyTask) throws -> Task {
-        
-        guard let task = taskAny as? OCKTask else{
+
+        guard let task = taskAny as? OCKTask else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
-        
+
         let encoded = try ParseCareKitUtility.encoder().encode(task)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
@@ -356,45 +366,45 @@ public final class Task: PCKVersionable {
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKTask.self, from: encoded)
     }
-    
+
     ///Link versions and related classes
-    public func linkRelated(completion: @escaping(Result<Task,Error>)->Void){
-        
+    public func linkRelated(completion: @escaping(Result<Task, Error>) -> Void) {
+
         self.linkVersions { result in
-            
+
             var updatedTask: Task
-            
+
             switch result {
-            
+
             case .success(let linked):
                 updatedTask = linked
-                
-            case .failure(_):
+
+            case .failure:
                 updatedTask = self
             }
-        
+
             guard let carePlanUUID = self.carePlanUUID else {
                 //Finished if there's no CarePlan, otherwise see if it's in the cloud
                 completion(.success(updatedTask))
                 return
             }
-            
+
             CarePlan.first(carePlanUUID, relatedObject: updatedTask.carePlan) { result in
-                
+
                 if case let .success(carePlan) = result {
                     updatedTask.carePlan = carePlan
                 }
-                
+
                 completion(.success(updatedTask))
             }
         }
     }
-    
+
     public func stampRelational() throws -> Task {
         var stamped = self
         stamped = try stamped.stampRelationalEntities()
         //stamped.elements?.forEach{$0.stamp(self.logicalClock!)}
-        
+
         return stamped
     }
 }
@@ -414,4 +424,3 @@ extension Task {
         encodingForParse = true
     }
 }
-

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -148,7 +148,7 @@ public final class Task: PCKVersionable {
         }
         
         //Check to see if already in the cloud
-        let query = Task.query(kPCKObjectableUUIDKey == uuid)
+        let query = Task.query(ObjectableKey.uuid == uuid)
         query.first(callbackQueue: .main){ result in
             
             switch result {
@@ -194,8 +194,8 @@ public final class Task: PCKVersionable {
         }
         
         //Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Task.query(containedIn(key: kPCKObjectableUUIDKey, array: [uuid, previousVersionUUID]))
-            .include([kPCKTaskCarePlanKey, kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Task.query(containedIn(key: ObjectableKey.uuid, array: [uuid, previousVersionUUID]))
+            .include([TaskKey.carePlan, VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             
             switch results {
@@ -245,9 +245,9 @@ public final class Task: PCKVersionable {
     
     public func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void){
         
-        let query = Task.query(kPCKObjectableClockKey >= localClock)
-            .order([.ascending(kPCKObjectableClockKey), .ascending(kPCKParseCreatedAtKey)])
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Task.query(ObjectableKey.logicalClock >= localClock)
+            .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main){ results in
             switch results {
             
@@ -264,9 +264,9 @@ public final class Task: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
+                        Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(ObjectableKey.logicalClock, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .task, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .task, type: .debug, ObjectableKey.logicalClock, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -23,13 +23,13 @@ import os.log
 /// their daily completion rings.
 public final class Task: PCKVersionable {
 
-    public internal(set) var nextVersion: Task? {
+    public var nextVersion: Task? {
         didSet {
             nextVersionUUID = nextVersion?.uuid
         }
     }
 
-    public internal(set) var nextVersionUUID: UUID? {
+    public var nextVersionUUID: UUID? {
         didSet {
             if nextVersionUUID != nextVersion?.uuid {
                 nextVersion = nil
@@ -37,13 +37,13 @@ public final class Task: PCKVersionable {
         }
     }
 
-    public internal(set) var previousVersion: Task? {
+    public var previousVersion: Task? {
         didSet {
             previousVersionUUID = previousVersion?.uuid
         }
     }
 
-    public internal(set) var previousVersionUUID: UUID? {
+    public var previousVersionUUID: UUID? {
         didSet {
             if previousVersionUUID != previousVersion?.uuid {
                 previousVersion = nil
@@ -53,19 +53,19 @@ public final class Task: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public internal(set) var uuid: UUID?
+    public var uuid: UUID?
 
-    var entityId: String?
+    public var entityId: String?
 
-    public internal(set) var logicalClock: Int?
+    public var logicalClock: Int?
 
-    public internal(set) var schemaVersion: OCKSemanticVersion?
+    public var schemaVersion: OCKSemanticVersion?
 
-    public internal(set) var createdDate: Date?
+    public var createdDate: Date?
 
-    public internal(set) var updatedDate: Date?
+    public var updatedDate: Date?
 
-    public internal(set) var deletedDate: Date?
+    public var deletedDate: Date?
 
     public var timezone: TimeZone?
 
@@ -83,7 +83,7 @@ public final class Task: PCKVersionable {
 
     public var remoteID: String?
 
-    var encodingForParse: Bool = true {
+    public var encodingForParse: Bool = true {
         willSet {
             prepareEncodingRelational(newValue)
         }
@@ -97,9 +97,16 @@ public final class Task: PCKVersionable {
 
     public var ACL: ParseACL?
 
+    /// If true, completion of this task will be factored into the patient's overall adherence. True by default.
     public var impactsAdherence: Bool?
+
+    /// Instructions about how this task should be performed.
     public var instructions: String?
+
+    /// A title that will be used to represent this task to the patient.
     public var title: String?
+
+    /// A schedule that specifies how often this task occurs.
     public var schedule: OCKSchedule?
 
     /// The care plan to which this task belongs.

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -345,7 +345,7 @@ public final class Task: PCKVersionable {
     }
 
     //Note that Tasks have to be saved to CareKit first in order to properly convert Outcome to CareKit
-    public func convertToCareKit(fromCloud:Bool=true) throws -> OCKTask {
+    public func convertToCareKit() throws -> OCKTask {
         self.encodingForParse = false
         let encoded = try ParseCareKitUtility.jsonEncoder().encode(self)
         return try ParseCareKitUtility.decoder().decode(OCKTask.self, from: encoded)

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -89,7 +89,7 @@ public final class Task: PCKVersionable {
     
     public var updatedAt: Date?
     
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
     
 
     public var impactsAdherence:Bool?
@@ -337,6 +337,7 @@ public final class Task: PCKVersionable {
         let encoded = try ParseCareKitUtility.encoder().encode(task)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
+        decoded.ACL = try? ParseACL.defaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -127,9 +127,9 @@ public final class Task: PCKVersionable {
             return try Self.copyCareKit(entity)
         default:
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.task.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
+                Logger.task.error("new(with:) The wrong type (\(careKitEntity.entityType, privacy: .private)) of entity was passed as an argument.")
             } else {
-                os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .task, type: .error, careKitEntity.entityType.debugDescription)
+                os_log("new(with:) The wrong type (%{private}@) of entity was passed.", log: .task, type: .error, careKitEntity.entityType.debugDescription)
             }
             throw ParseCareKitError.classTypeNotAnEligibleType
         }
@@ -169,9 +169,9 @@ public final class Task: PCKVersionable {
                 default:
                     //There was a different issue that we don't know how to handle
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.task.error("addToCloud(), \(error.localizedDescription)")
+                        Logger.task.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("addToCloud(), %{public}@", log: .task, type: .error, error.localizedDescription)
+                        os_log("addToCloud(), %{private}@", log: .task, type: .error, error.localizedDescription)
                     }
                     completion(.failure(error))
                 }
@@ -229,9 +229,9 @@ public final class Task: PCKVersionable {
                 }
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.task.error("updateCloud(), \(error.localizedDescription)")
+                    Logger.task.error("updateCloud(), \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("updateCloud(), %{public}", log: .task, type: .error, error.localizedDescription)
+                    os_log("updateCloud(), %{private}", log: .task, type: .error, error.localizedDescription)
                 }
                 completion(.failure(error))
             }
@@ -259,15 +259,15 @@ public final class Task: PCKVersionable {
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
+                        Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .task, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
+                        os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{private}", log: .task, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.task.debug("An unexpected error occured \(error.localizedDescription)")
+                        Logger.task.debug("An unexpected error occured \(error.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("An unexpected error occured \"%{public}", log: .task, type: .debug, error.localizedDescription)
+                        os_log("An unexpected error occured \"%{private}", log: .task, type: .debug, error.localizedDescription)
                     }
                 }
                 mergeRevision(revision)

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -126,7 +126,7 @@ public final class Task: PCKVersionable {
         case .task(let entity):
             return try Self.copyCareKit(entity)
         default:
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.task.error("new(with:) The wrong type (\(careKitEntity.entityType)) of entity was passed as an argument.")
             } else {
                 os_log("new(with:) The wrong type (%{public}@) of entity was passed.", log: .task, type: .error, careKitEntity.entityType.debugDescription)
@@ -168,7 +168,7 @@ public final class Task: PCKVersionable {
                         self.save(completion: completion)
                 default:
                     //There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.error("addToCloud(), \(error.localizedDescription)")
                     } else {
                         os_log("addToCloud(), %{public}@", log: .task, type: .error, error.localizedDescription)
@@ -198,7 +198,7 @@ public final class Task: PCKVersionable {
             case .success(let foundObjects):
                 switch foundObjects.count{
                 case 0:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new")
                     } else {
                         os_log("updateCloud(), A previous version is suppose to exist in the Cloud, but isn't present, saving as new", log: .task, type: .debug)
@@ -207,7 +207,7 @@ public final class Task: PCKVersionable {
                 case 1:
                     //This is the typical case
                     guard let previousVersion = foundObjects.first(where: {$0.uuid == previousVersionUUID}) else {
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.task.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUID, privacy: .private)) already exists in Cloud")
                         } else {
                             os_log("updateCloud(), Didn't find previousVersion of this UUID (%{private}) already exists in Cloud", log: .task, type: .error, previousVersionUUID.uuidString)
@@ -220,7 +220,7 @@ public final class Task: PCKVersionable {
                     updated.addToCloud(overwriteRemote: false, completion: completion)
 
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.error("updateCloud(), UUID (\(uuid, privacy: .private)) already exists in Cloud")
                     } else {
                         os_log("updateCloud(), UUID (%{private}) already exists in Cloud", log: .task, type: .error, uuid.uuidString)
@@ -228,7 +228,7 @@ public final class Task: PCKVersionable {
                     completion(.failure(ParseCareKitError.uuidAlreadyExists))
                 }
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.task.error("updateCloud(), \(error.localizedDescription)")
                 } else {
                     os_log("updateCloud(), %{public}", log: .task, type: .error, error.localizedDescription)
@@ -258,13 +258,13 @@ public final class Task: PCKVersionable {
                 case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
                     //If the query was looking in a column that wasn't a default column, it will return nil if the table doesn't contain the custom column
                     //Saving the new item with the custom column should resolve the issue
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("Warning, the table either doesn't exist or is missing the column \"\(kPCKObjectableClockKey, privacy: .private)\". It should be fixed during the first sync... ParseError: \(error.localizedDescription)")
                     } else {
                         os_log("Warning, the table either doesn't exist or is missing the column \"%{private}\" It should be fixed during the first sync... ParseError: \"%{public}", log: .task, type: .debug, kPCKObjectableClockKey, error.localizedDescription)
                     }
                 default:
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.task.debug("An unexpected error occured \(error.localizedDescription)")
                     } else {
                         os_log("An unexpected error occured \"%{public}", log: .task, type: .debug, error.localizedDescription)

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -113,6 +113,11 @@ public final class Task: PCKVersionable {
         }
     }
 
+    /// A textual representation of this instance, suitable for debugging.
+    public var localizedDescription: String {
+        "\(debugDescription) impactsAdherence=\(String(describing: impactsAdherence)) title=\(String(describing: title)) instructions=\(String(describing: instructions)) schedule=\(String(describing: schedule)) carePlanUUID=\(String(describing: carePlanUUID)) carePlan=\(String(describing: carePlan))"
+    }
+
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
         case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock

--- a/Sources/ParseCareKit/Parse/PCKUser.swift
+++ b/Sources/ParseCareKit/Parse/PCKUser.swift
@@ -11,16 +11,16 @@ import ParseSwift
 
 struct PCKUser: ParseUser {
     var username: String?
-    
+
     var email: String?
-    
+
     var password: String?
-    
+
     var objectId: String?
-    
+
     var createdAt: Date?
-    
+
     var updatedAt: Date?
-    
+
     var ACL: ParseACL?
 }

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ParseSwift
 import CareKitStore
+import os.log
 
 // #Mark - Custom Enums
 public enum PCKCodingKeys: String, CodingKey { // swiftlint:disable:this nesting
@@ -68,7 +69,7 @@ extension ParseCareKitError: LocalizedError {
 }
 
 /// Types of ParseCareKit classes.
-public enum PCKStoreClass {
+public enum PCKStoreClass: String {
     case carePlan
     case contact
     case outcome
@@ -106,7 +107,11 @@ public enum PCKStoreClass {
             if isCorrectType(key, check: value){
                 updatedClasses[key] = value
             }else{
-                print("**** Warning in PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile -> \(value)")
+                if #available(iOS 14.0, *) {
+                    Logger.pullRevisions.debug("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
+                } else {
+                    os_log("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.", log: .pullRevisions, type: .debug, key.rawValue)
+                }
             }
         }
         return updatedClasses
@@ -143,7 +148,11 @@ public enum PCKStoreClass {
             if isCorrectType(key, check: value){
                 updatedClasses[key] = value
             }else{
-                print("**** Warning in PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile -> \(value)")
+                if #available(iOS 14.0, *) {
+                    Logger.pullRevisions.debug("PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
+                } else {
+                    os_log("PCKStoreClass.replaceConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile -> %{public}@.", log: .pullRevisions, type: .debug, key.rawValue)
+                }
             }
         }
         return updatedClasses
@@ -307,3 +316,34 @@ public let kPCKOutcomUserInfoIDKey              = "entityId"
 //OutcomeValue Class
 public let kPCKOutcomeValueUserInfoUUIDKey              = "uuid"
 public let kPCKOutcomeValueUserInfoRelatedOutcomeIDKey = "relatedOutcomeID"
+
+extension OSLog {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    
+    static let carePlan = OSLog(subsystem: subsystem, category: "carePlan")
+    static let contact = OSLog(subsystem: subsystem, category: "carePlan")
+    static let patient = OSLog(subsystem: subsystem, category: "patient")
+    static let task = OSLog(subsystem: subsystem, category: "task")
+    static let outcome = OSLog(subsystem: subsystem, category: "outcome")
+    static let versionable = OSLog(subsystem: subsystem, category: "versionable")
+    static let objectable = OSLog(subsystem: subsystem, category: "objectable")
+    static let pullRevisions = OSLog(subsystem: subsystem, category: "pullRevisions")
+    static let pushRevisions = OSLog(subsystem: subsystem, category: "pushRevisions")
+    static let clock = OSLog(subsystem: subsystem, category: "clock")
+}
+
+@available(iOS 14.0, *)
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    
+    static let carePlan = Logger(subsystem: subsystem, category: "carePlan")
+    static let contact = Logger(subsystem: subsystem, category: "carePlan")
+    static let patient = Logger(subsystem: subsystem, category: "patient")
+    static let task = Logger(subsystem: subsystem, category: "task")
+    static let outcome = Logger(subsystem: subsystem, category: "outcome")
+    static let versionable = Logger(subsystem: subsystem, category: "versionable")
+    static let objectable = Logger(subsystem: subsystem, category: "objectable")
+    static let pullRevisions = Logger(subsystem: subsystem, category: "pullRevisions")
+    static let pushRevisions = Logger(subsystem: subsystem, category: "pushRevisions")
+    static let clock = Logger(subsystem: subsystem, category: "clock")
+}

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -107,7 +107,7 @@ public enum PCKStoreClass: String {
             if isCorrectType(key, check: value){
                 updatedClasses[key] = value
             }else{
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
                     os_log("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.", log: .pullRevisions, type: .debug, key.rawValue)
@@ -148,7 +148,7 @@ public enum PCKStoreClass: String {
             if isCorrectType(key, check: value){
                 updatedClasses[key] = value
             }else{
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
                     os_log("PCKStoreClass.replaceConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile -> %{public}@.", log: .pullRevisions, type: .debug, key.rawValue)
@@ -332,7 +332,7 @@ extension OSLog {
     static let clock = OSLog(subsystem: subsystem, category: "clock")
 }
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, *)
 extension Logger {
     private static var subsystem = Bundle.main.bundleIdentifier!
     

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -11,14 +11,18 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable line_length
+
 // #Mark - Custom Enums
 enum CustomKey {
     static let customClass                                  = "customClass"
 }
 
-public enum PCKCodingKeys: String, CodingKey { // swiftlint:disable:this nesting
-    case entityId, id
-    case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock, className, ACL, objectId, updatedAt, createdAt
+public enum PCKCodingKeys: String, CodingKey {
+    case entityId, id // swiftlint:disable:this identifier_name
+    case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone,
+         userInfo, groupIdentifier, tags, source, asset, remoteID, notes,
+         logicalClock, className, ACL, objectId, updatedAt, createdAt
     case nextVersion, previousVersion, effectiveDate, previousVersionUUID, nextVersionUUID
 }
 
@@ -29,7 +33,7 @@ public enum PCKStoreClass: String {
     case outcome
     case patient
     case task
-    
+
     func getDefault() throws -> PCKSynchronizable {
         switch self {
         case .carePlan:
@@ -45,22 +49,23 @@ public enum PCKStoreClass: String {
             let patient = OCKPatient(id: "", givenName: "", familyName: "")
             return try Patient.copyCareKit(patient)
         case .task:
-            let task = OCKTask(id: "", title: "", carePlanUUID: nil, schedule: .init(composing: [.init(start: Date(), end: nil, interval: .init(day: 1))]))
+            let task = OCKTask(id: "", title: "", carePlanUUID: nil,
+                               schedule: .init(composing: [.init(start: Date(), end: nil, interval: .init(day: 1))]))
             return try Task.copyCareKit(task)
         }
     }
-    
-    func orderedArray() -> [PCKStoreClass]{
+
+    func orderedArray() -> [PCKStoreClass] {
         return [.patient, .carePlan, .contact, .task, .outcome]
     }
-    
-    func replaceRemoteConcreteClasses(_ newClasses: [PCKStoreClass: PCKSynchronizable])throws -> [PCKStoreClass: PCKSynchronizable] {
+
+    func replaceRemoteConcreteClasses(_ newClasses: [PCKStoreClass: PCKSynchronizable]) throws -> [PCKStoreClass: PCKSynchronizable] {
         var updatedClasses = try getConcrete()
 
-        for (key,value) in newClasses{
-            if isCorrectType(key, check: value){
+        for (key, value) in newClasses {
+            if isCorrectType(key, check: value) {
                 updatedClasses[key] = value
-            }else{
+            } else {
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key.rawValue, privacy: .private)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
@@ -70,9 +75,9 @@ public enum PCKStoreClass: String {
         }
         return updatedClasses
     }
-    
+
     func getConcrete() throws -> [PCKStoreClass: PCKSynchronizable] {
-        
+
         var concreteClasses: [PCKStoreClass: PCKSynchronizable] = [
             .carePlan: try PCKStoreClass.carePlan.getDefault(),
             .contact: try PCKStoreClass.contact.getDefault(),
@@ -80,28 +85,28 @@ public enum PCKStoreClass: String {
             .patient: try PCKStoreClass.patient.getDefault(),
             .task: try PCKStoreClass.task.getDefault()
         ]
-        
-        for (key,value) in concreteClasses{
-            if !isCorrectType(key, check: value){
+
+        for (key, value) in concreteClasses {
+            if !isCorrectType(key, check: value) {
                 concreteClasses.removeValue(forKey: key)
             }
         }
-        
+
         //Ensure all default classes are created
-        guard concreteClasses.count == orderedArray().count else{
+        guard concreteClasses.count == orderedArray().count else {
             throw ParseCareKitError.couldntCreateConcreteClasses
         }
-        
+
         return concreteClasses
     }
-    
+
     func replaceConcreteClasses(_ newClasses: [PCKStoreClass: PCKSynchronizable]) throws -> [PCKStoreClass: PCKSynchronizable] {
         var updatedClasses = try getConcrete()
 
-        for (key,value) in newClasses{
-            if isCorrectType(key, check: value){
+        for (key, value) in newClasses {
+            if isCorrectType(key, check: value) {
                 updatedClasses[key] = value
-            }else{
+            } else {
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key.rawValue, privacy: .private)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
@@ -111,31 +116,31 @@ public enum PCKStoreClass: String {
         }
         return updatedClasses
     }
-    
-    func isCorrectType(_ type: PCKStoreClass, check: PCKSynchronizable) -> Bool{
+
+    func isCorrectType(_ type: PCKStoreClass, check: PCKSynchronizable) -> Bool {
         switch type {
         case .carePlan:
-            guard let _ = check as? CarePlan else{
+            guard (check as? CarePlan) != nil else {
                 return false
             }
             return true
         case .contact:
-            guard let _ = check as? Contact else{
+            guard (check as? Contact) != nil else {
                 return false
             }
             return true
         case .outcome:
-            guard let _ = check as? Outcome else{
+            guard (check as? Outcome) != nil else {
                 return false
             }
             return true
         case .patient:
-            guard let _ = check as? Patient else{
+            guard (check as? Patient) != nil else {
                 return false
             }
             return true
         case .task:
-            guard let _ = check as? Task else{
+            guard (check as? Task) != nil else {
                 return false
             }
             return true

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -12,60 +12,14 @@ import CareKitStore
 import os.log
 
 // #Mark - Custom Enums
+enum CustomKey {
+    static let customClass                                  = "customClass"
+}
+
 public enum PCKCodingKeys: String, CodingKey { // swiftlint:disable:this nesting
     case entityId, id
     case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock, className, ACL, objectId, updatedAt, createdAt
     case nextVersion, previousVersion, effectiveDate, previousVersionUUID, nextVersionUUID
-}
-
-
-enum ParseCareKitError: Error {
-    case userNotLoggedIn
-    case relatedEntityNotInCloud
-    case requiredValueCantBeUnwrapped
-    case objectIdDoesntMatchRemoteId
-    case objectNotFoundOnParseServer
-    case cloudClockLargerThanLocalWhilePushRevisions
-    case couldntUnwrapClock
-    case cantUnwrapSelf
-    case cloudVersionNewerThanLocal
-    case uuidAlreadyExists
-    case cantCastToNeededClassType
-    case classTypeNotAnEligibleType
-    case couldntCreateConcreteClasses
-}
-
-extension ParseCareKitError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case .userNotLoggedIn:
-            return NSLocalizedString("ParseCareKit: Parse User isn't logged in.", comment: "Login error")
-        case .relatedEntityNotInCloud:
-            return NSLocalizedString("ParseCareKit: Related entity isn't in cloud.", comment: "Related entity error")
-        case .requiredValueCantBeUnwrapped:
-            return NSLocalizedString("ParseCareKit: Required value can't be unwrapped.", comment: "Unwrapping error")
-        case .couldntUnwrapClock:
-            return NSLocalizedString("ParseCareKit: Clock can't be unwrapped.", comment: "Clock Unwrapping error")
-        case .objectIdDoesntMatchRemoteId:
-            return NSLocalizedString("ParseCareKit: remoteId and objectId don't match.", comment: "Remote/Local mismatch error")
-        case .cloudClockLargerThanLocalWhilePushRevisions:
-            return NSLocalizedString("Cloud clock larger than local during pushRevisions, not pushing", comment: "Knowledge vector larger in Cloud")
-        case .cantUnwrapSelf:
-            return NSLocalizedString("Can't unwrap self. This class has already been deallocated", comment: "Can't unwrap self, class deallocated")
-        case .cloudVersionNewerThanLocal:
-            return NSLocalizedString("Can't sync, the Cloud version newere than local version", comment: "Cloud version newer than local version")
-        case .uuidAlreadyExists:
-            return NSLocalizedString("Can't sync, the uuid already exists in the Cloud", comment: "UUID isn't unique")
-        case .cantCastToNeededClassType:
-            return NSLocalizedString("Can't cast to needed class type", comment: "Can't cast to needed class type")
-        case .classTypeNotAnEligibleType:
-            return NSLocalizedString("PCKClass type isn't an eligible type", comment: "PCKClass type isn't an eligible type")
-        case .couldntCreateConcreteClasses:
-            return NSLocalizedString("Couldn't create concrete classes", comment: "Couldn't create concrete classes")
-        case .objectNotFoundOnParseServer:
-            return NSLocalizedString("Object couldn't be found on the Parse Server", comment: "Object couldn't be found on the Parse Server")
-        }
-    }
 }
 
 /// Types of ParseCareKit classes.
@@ -189,130 +143,106 @@ public enum PCKStoreClass: String {
     }
 }
 
-public let kPCKCustomClassKey                                       = "customClass"
-
 //#Mark - Parse Database Keys
+public enum ParseKey {
+    static let objectId = "objectId"
+    static let createdAt = "createdAt"
+    static let ACL = "ACL"
+}
 
-public let kPCKParseObjectIdKey                                     = "objectId"
-public let kPCKParseCreatedAtKey                                    = "createdAt"
-public let kPCKParseUpdatedAtKey                                    = "updatedAt"
+public enum ObjectableKey {
+    static let uuid                                       = "uuid"
+    static let entityId                                   = "entityId"
+    static let asset                                      = "asset"
+    static let groupIdentifier                            = "groupIdentifier"
+    static let notes                                      = "notes"
+    static let timezone                                   = "timezone"
+    static let logicalClock                               = "logicalClock"
+    static let createdDate                                = "createdDate"
+    static let updatedDate                                = "updatedDate"
+    static let tags                                       = "tags"
+    static let userInfo                                   = "userInfo"
+    static let source                                     = "source"
+    static let remoteID                                   = "remoteID"
+}
 
-public let kPCKObjectableUUIDKey                                        = "uuid"
-public let kPCKObjectableEntityIdKey                                    = "entityId"
-public let kPCKObjectableAssetKey                                       = "asset"
-public let kPCKObjectableGroupIdentifierKey                             = "groupIdentifier"
-public let kPCKObjectableNotesKey                                       = "notes"
-public let kPCKObjectableTimezoneKey                                    = "timezone"
-public let kPCKObjectableClockKey                                       = "logicalClock"
-public let kPCKObjectableCreatedDateKey                                 = "createdDate"
-public let kPCKObjectableUpdatedDateKey                                 = "updatedDate"
-public let kPCKObjectableTagsKey                                        = "tags"
-public let kPCKObjectableUserInfoKey                                    = "userInfo"
-public let kPCKObjectableSourceKey                                      = "source"
-public let kPCKObjectableDeletedDateKey                                 = "deletedDate"
-public let kPCKObjectableRemoteIDKey                                    = "remoteID"
-
-public let kPCKVersionedObjectEffectiveDateKey                      = "effectiveDate"
-
-public let kPCKVersionedObjectNextKey                               = "next"
-public let kPCKVersionedObjectPreviousKey                           = "previous"
+public enum VersionableKey {
+    static let deletedDate                                = "deletedDate"
+    static let effectiveDate                              = "effectiveDate"
+    static let next                                       = "next"
+    static let previous                                   = "previous"
+}
 
 //#Mark - Patient Class
-public let kPCKPatientClassKey                                 = "Patient"
-
-// Field keys
-public let kPCKPatientAllergiesKey                                  = "alergies"
-public let kPCKPatientBirthdayKey                                   = "birthday"
-public let kPCKPatientSexKey                                        = "sex"
-public let kPCKPatientNameKey                                       = "name"
+public enum PatientKey {
+    static let className                                = "Patient"
+    static let allergies                                = "alergies"
+    static let birthday                                 = "birthday"
+    static let sex                                      = "sex"
+    static let name                                     = "name"
+}
 
 //#Mark - CarePlan Class
-public let kPCKCarePlanClassKey                                = "CarePlan"
-
-// Field keys
-public let kPCKCarePlanPatientKey                                 = "patient"
-public let kPCKCarePlanTitleKey                                   = "title"
+public enum CarePlanKey {
+    static let className                                = "CarePlan"
+    static let patient                                  = "patient"
+    static let title                                    = "title"
+}
 
 //#Mark - Contact Class
-public let kPCKContactClassKey                                 = "Contact"
-
-// Field keys
-public let kPCKContactCarePlanKey                                 = "carePlan"
-public let kPCKContactTitleKey                                    = "title"
-public let kPCKContactRoleKey                                     = "role"
-public let kPCKContactOrganizationKey                             = "organization"
-public let kPCKContactCategoryKey                                 = "category"
-public let kPCKContactNameKey                                     = "name"
-public let kPCKContactAddressKey                                  = "address"
-public let kPCKContactEmailAddressesKey                           = "emailAddressesDictionary"
-public let kPCKContactPhoneNumbersKey                             = "phoneNumbersDictionary"
-public let kPCKContactMessagingNumbersKey                         = "messagingNumbersDictionary"
-public let kPCKContactOtherContactInfoKey                         = "otherContactInfoDictionary"
-
+public enum ContactKey {
+    static let className                                = "Contact"
+    static let carePlan                                 = "carePlan"
+    static let title                                    = "title"
+    static let role                                     = "role"
+    static let organization                             = "organization"
+    static let category                                 = "category"
+    static let name                                     = "name"
+    static let address                                  = "address"
+    static let emailAddresses                           = "emailAddresses"
+    static let phoneNumbers                             = "phoneNumbers"
+    static let messagingNumbers                         = "messagingNumbers"
+    static let otherContactInfo                         = "otherContactInfo"
+}
 
 //#Mark - Task Class
-public let kPCKTaskClassKey                                    = "Task"
-
-// Field keys
-public let kPCKTaskTitleKey                                       = "title"
-public let kPCKTaskCarePlanKey                                    = "carePlan"
-public let kPCKTaskImpactsAdherenceKey                         = "impactsAdherence"
-public let kPCKTaskInstructionsKey                             = "instructions"
-public let kPCKTaskElementsKey                                 = "elements"
-
-//#Mark - Schedule Element Class
-public let kAScheduleElementClassKey                           = "ScheduleElement"
-// Field keys
-public let kPCKScheduleElementTextKey                             = "text"
-public let kPCKScheduleElementStartKey                            = "start"
-public let kPCKScheduleElementEndKey                              = "end"
-public let kPCKScheduleElementIntervalKey                         = "interval"
-public let kPCKScheduleElementTargetValuesKey                     = "targetValues"
-public let kPCKScheduleElementElementsKey                         = "elements"
+public enum TaskKey {
+    static let className                                = "Task"
+    static let title                                    = "title"
+    static let carePlan                                 = "carePlan"
+    static let impactsAdherence                         = "impactsAdherence"
+    static let instructions                             = "instructions"
+    static let elements                                 = "elements"
+}
 
 //#Mark - Outcome Class
-public let kPCKOutcomeClassKey                                    = "Outcome"
-
-// Field keys
-public let kPCKOutcomeTaskKey                                     = "task"
-public let kPCKOutcomeTaskOccurrenceIndexKey                   = "taskOccurrenceIndex"
-public let kPCKOutcomeValuesKey                                = "values"
-
+public enum OutcomeKey {
+    static let className                                = "Outcome"
+    static let deletedDate                              = "deletedDate"
+    static let task                                     = "task"
+    static let taskOccurrenceIndex                      = "taskOccurrenceIndex"
+    static let values                                   = "values"
+}
 
 //#Mark - OutcomeValue Class
-public let kPCKOutcomeValueClassKey                            = "OutcomeValue"
-
-// Field keys
-public let kPCKOutcomeValueIndexKey                               = "index"
-public let kPCKOutcomeValueKindKey                             = "kind"
-public let kPCKOutcomeValueUnitsKey                            = "units"
-public let kPCKOutcomeValueValueKey                            = "textValue"
-public let kPCKOutcomeValueBinaryValueKey                            = "binaryValue"
-public let kPCKOutcomeValueBooleanValueKey                            = "booleanValue"
-public let kPCKOutcomeValueIntegerValueKey                            = "integerValue"
-public let kPCKOutcomeValueDoubleValueKey                            = "doubleValue"
-public let kPCKOutcomeValueDateValueKey                            = "dateValue"
-
+public enum OutcomeValueKey {
+    static let className                                = "OutcomeValue"
+    static let indexKey                                 = "index"
+    static let kindKey                                  = "kind"
+    static let unitsKey                                 = "units"
+}
 
 //#Mark - Note Class
-public let kPCKNoteClassKey                                    = "Note"
-// Field keys
-public let kPCKNoteContentKey                                  = "content"
-public let kPCKNoteTitleKey                                    = "title"
-public let kPCKNoteAuthorKey                                   = "author"
+public enum NoteKey {
+    static let className                                = "Note"
+    static let contentKey                               = "content"
+    static let titleKey                                 = "title"
+    static let authorKey                                = "author"
+}
 
 //#Mark - Clock Class
-public let kPCKClockClassKey                         = "Clock"
-// Field keys
-public let kPCKClockPatientTypeUUIDKey               = "uuid"
-public let kPCKClockVectorKey                        = "vector"
-
-
-//#Mark - CareKit UserInfo Database Keys
-
-//Outcome Class (keep this as Outcome has had issues querying multiple times)
-public let kPCKOutcomUserInfoIDKey              = "entityId"
-
-//OutcomeValue Class
-public let kPCKOutcomeValueUserInfoUUIDKey              = "uuid"
-public let kPCKOutcomeValueUserInfoRelatedOutcomeIDKey = "relatedOutcomeID"
+public enum ClockKey {
+    static let className                                = "Clock"
+    static let uuid                                     = "uuid"
+    static let vectorKey                                = "vector"
+}

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -108,9 +108,9 @@ public enum PCKStoreClass: String {
                 updatedClasses[key] = value
             }else{
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.pullRevisions.debug("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
+                    Logger.pullRevisions.debug("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `\(key.rawValue, privacy: .private)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
-                    os_log("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.", log: .pullRevisions, type: .debug, key.rawValue)
+                    os_log("PCKStoreClass.replaceRemoteConcreteClasses(). Discarding class for `%{private}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.", log: .pullRevisions, type: .debug, key.rawValue)
                 }
             }
         }
@@ -149,9 +149,9 @@ public enum PCKStoreClass: String {
                 updatedClasses[key] = value
             }else{
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.pullRevisions.debug("PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key.rawValue)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
+                    Logger.pullRevisions.debug("PCKStoreClass.replaceConcreteClasses(). Discarding class for `\(key.rawValue, privacy: .private)` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.")
                 } else {
-                    os_log("PCKStoreClass.replaceConcreteClasses(). Discarding class for `%{public}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile -> %{public}@.", log: .pullRevisions, type: .debug, key.rawValue)
+                    os_log("PCKStoreClass.replaceConcreteClasses(). Discarding class for `%{private}@` because it's of the wrong type. All classes need to subclass a PCK concrete type. If you are trying to map a class to a OCKStore concreate type, pass it to `customClasses` instead. This class isn't compatibile.", log: .pullRevisions, type: .debug, key.rawValue)
                 }
             }
         }
@@ -316,34 +316,3 @@ public let kPCKOutcomUserInfoIDKey              = "entityId"
 //OutcomeValue Class
 public let kPCKOutcomeValueUserInfoUUIDKey              = "uuid"
 public let kPCKOutcomeValueUserInfoRelatedOutcomeIDKey = "relatedOutcomeID"
-
-extension OSLog {
-    private static var subsystem = Bundle.main.bundleIdentifier!
-    
-    static let carePlan = OSLog(subsystem: subsystem, category: "carePlan")
-    static let contact = OSLog(subsystem: subsystem, category: "carePlan")
-    static let patient = OSLog(subsystem: subsystem, category: "patient")
-    static let task = OSLog(subsystem: subsystem, category: "task")
-    static let outcome = OSLog(subsystem: subsystem, category: "outcome")
-    static let versionable = OSLog(subsystem: subsystem, category: "versionable")
-    static let objectable = OSLog(subsystem: subsystem, category: "objectable")
-    static let pullRevisions = OSLog(subsystem: subsystem, category: "pullRevisions")
-    static let pushRevisions = OSLog(subsystem: subsystem, category: "pushRevisions")
-    static let clock = OSLog(subsystem: subsystem, category: "clock")
-}
-
-@available(iOS 14.0, watchOS 7.0, *)
-extension Logger {
-    private static var subsystem = Bundle.main.bundleIdentifier!
-    
-    static let carePlan = Logger(subsystem: subsystem, category: "carePlan")
-    static let contact = Logger(subsystem: subsystem, category: "carePlan")
-    static let patient = Logger(subsystem: subsystem, category: "patient")
-    static let task = Logger(subsystem: subsystem, category: "task")
-    static let outcome = Logger(subsystem: subsystem, category: "outcome")
-    static let versionable = Logger(subsystem: subsystem, category: "versionable")
-    static let objectable = Logger(subsystem: subsystem, category: "objectable")
-    static let pullRevisions = Logger(subsystem: subsystem, category: "pullRevisions")
-    static let pushRevisions = Logger(subsystem: subsystem, category: "pushRevisions")
-    static let clock = Logger(subsystem: subsystem, category: "clock")
-}

--- a/Sources/ParseCareKit/ParseCareKitError.swift
+++ b/Sources/ParseCareKit/ParseCareKitError.swift
@@ -14,7 +14,7 @@ enum ParseCareKitError: Error {
     case requiredValueCantBeUnwrapped
     case objectIdDoesntMatchRemoteId
     case objectNotFoundOnParseServer
-    case cloudClockLargerThanLocalWhilePushRevisions
+    case cloudClockLargerThanLocal
     case couldntUnwrapClock
     case cantUnwrapSelf
     case cloudVersionNewerThanLocal
@@ -36,23 +36,31 @@ extension ParseCareKitError: LocalizedError {
         case .couldntUnwrapClock:
             return NSLocalizedString("ParseCareKit: Clock can't be unwrapped.", comment: "Clock Unwrapping error")
         case .objectIdDoesntMatchRemoteId:
-            return NSLocalizedString("ParseCareKit: remoteId and objectId don't match.", comment: "Remote/Local mismatch error")
-        case .cloudClockLargerThanLocalWhilePushRevisions:
-            return NSLocalizedString("Cloud clock larger than local during pushRevisions, not pushing", comment: "Knowledge vector larger in Cloud")
+            return NSLocalizedString("ParseCareKit: remoteId and objectId don't match.",
+                                     comment: "Remote/Local mismatch error")
+        case .cloudClockLargerThanLocal:
+            return NSLocalizedString("Cloud clock larger than local during pushRevisions, not pushing",
+                                     comment: "Knowledge vector larger in Cloud")
         case .cantUnwrapSelf:
-            return NSLocalizedString("Can't unwrap self. This class has already been deallocated", comment: "Can't unwrap self, class deallocated")
+            return NSLocalizedString("Can't unwrap self. This class has already been deallocated",
+                                     comment: "Can't unwrap self, class deallocated")
         case .cloudVersionNewerThanLocal:
-            return NSLocalizedString("Can't sync, the Cloud version newere than local version", comment: "Cloud version newer than local version")
+            return NSLocalizedString("Can't sync, the Cloud version newere than local version",
+                                     comment: "Cloud version newer than local version")
         case .uuidAlreadyExists:
             return NSLocalizedString("Can't sync, the uuid already exists in the Cloud", comment: "UUID isn't unique")
         case .cantCastToNeededClassType:
-            return NSLocalizedString("Can't cast to needed class type", comment: "Can't cast to needed class type")
+            return NSLocalizedString("Can't cast to needed class type",
+                                     comment: "Can't cast to needed class type")
         case .classTypeNotAnEligibleType:
-            return NSLocalizedString("PCKClass type isn't an eligible type", comment: "PCKClass type isn't an eligible type")
+            return NSLocalizedString("PCKClass type isn't an eligible type",
+                                     comment: "PCKClass type isn't an eligible type")
         case .couldntCreateConcreteClasses:
-            return NSLocalizedString("Couldn't create concrete classes", comment: "Couldn't create concrete classes")
+            return NSLocalizedString("Couldn't create concrete classes",
+                                     comment: "Couldn't create concrete classes")
         case .objectNotFoundOnParseServer:
-            return NSLocalizedString("Object couldn't be found on the Parse Server", comment: "Object couldn't be found on the Parse Server")
+            return NSLocalizedString("Object couldn't be found on the Parse Server",
+                                     comment: "Object couldn't be found on the Parse Server")
         }
     }
 }

--- a/Sources/ParseCareKit/ParseCareKitError.swift
+++ b/Sources/ParseCareKit/ParseCareKitError.swift
@@ -1,0 +1,58 @@
+//
+//  ParseCareKitError.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 12/12/20.
+//  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+
+enum ParseCareKitError: Error {
+    case userNotLoggedIn
+    case relatedEntityNotInCloud
+    case requiredValueCantBeUnwrapped
+    case objectIdDoesntMatchRemoteId
+    case objectNotFoundOnParseServer
+    case cloudClockLargerThanLocalWhilePushRevisions
+    case couldntUnwrapClock
+    case cantUnwrapSelf
+    case cloudVersionNewerThanLocal
+    case uuidAlreadyExists
+    case cantCastToNeededClassType
+    case classTypeNotAnEligibleType
+    case couldntCreateConcreteClasses
+}
+
+extension ParseCareKitError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .userNotLoggedIn:
+            return NSLocalizedString("ParseCareKit: Parse User isn't logged in.", comment: "Login error")
+        case .relatedEntityNotInCloud:
+            return NSLocalizedString("ParseCareKit: Related entity isn't in cloud.", comment: "Related entity error")
+        case .requiredValueCantBeUnwrapped:
+            return NSLocalizedString("ParseCareKit: Required value can't be unwrapped.", comment: "Unwrapping error")
+        case .couldntUnwrapClock:
+            return NSLocalizedString("ParseCareKit: Clock can't be unwrapped.", comment: "Clock Unwrapping error")
+        case .objectIdDoesntMatchRemoteId:
+            return NSLocalizedString("ParseCareKit: remoteId and objectId don't match.", comment: "Remote/Local mismatch error")
+        case .cloudClockLargerThanLocalWhilePushRevisions:
+            return NSLocalizedString("Cloud clock larger than local during pushRevisions, not pushing", comment: "Knowledge vector larger in Cloud")
+        case .cantUnwrapSelf:
+            return NSLocalizedString("Can't unwrap self. This class has already been deallocated", comment: "Can't unwrap self, class deallocated")
+        case .cloudVersionNewerThanLocal:
+            return NSLocalizedString("Can't sync, the Cloud version newere than local version", comment: "Cloud version newer than local version")
+        case .uuidAlreadyExists:
+            return NSLocalizedString("Can't sync, the uuid already exists in the Cloud", comment: "UUID isn't unique")
+        case .cantCastToNeededClassType:
+            return NSLocalizedString("Can't cast to needed class type", comment: "Can't cast to needed class type")
+        case .classTypeNotAnEligibleType:
+            return NSLocalizedString("PCKClass type isn't an eligible type", comment: "PCKClass type isn't an eligible type")
+        case .couldntCreateConcreteClasses:
+            return NSLocalizedString("Couldn't create concrete classes", comment: "Couldn't create concrete classes")
+        case .objectNotFoundOnParseServer:
+            return NSLocalizedString("Object couldn't be found on the Parse Server", comment: "Object couldn't be found on the Parse Server")
+        }
+    }
+}

--- a/Sources/ParseCareKit/ParseCareKitLog.swift
+++ b/Sources/ParseCareKit/ParseCareKitLog.swift
@@ -1,0 +1,41 @@
+//
+//  ParseCareKitLog.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 12/12/20.
+//  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import os.log
+
+extension OSLog {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    static let category = "ParseCareKit"
+    static let carePlan = OSLog(subsystem: subsystem, category: "\(category).carePlan")
+    static let contact = OSLog(subsystem: subsystem, category: "\(category).carePlan")
+    static let patient = OSLog(subsystem: subsystem, category: "\(category).patient")
+    static let task = OSLog(subsystem: subsystem, category: "\(category).task")
+    static let outcome = OSLog(subsystem: subsystem, category: "\(category).outcome")
+    static let versionable = OSLog(subsystem: subsystem, category: "\(category).versionable")
+    static let objectable = OSLog(subsystem: subsystem, category: "\(category).objectable")
+    static let pullRevisions = OSLog(subsystem: subsystem, category: "\(category).pullRevisions")
+    static let pushRevisions = OSLog(subsystem: subsystem, category: "\(category).pushRevisions")
+    static let clock = OSLog(subsystem: subsystem, category: "\(category).clock")
+}
+
+@available(iOS 14.0, watchOS 7.0, *)
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    static let category = "ParseCareKit"
+    static let carePlan = Logger(subsystem: subsystem, category: "\(category).carePlan")
+    static let contact = Logger(subsystem: subsystem, category: "\(category).carePlan")
+    static let patient = Logger(subsystem: subsystem, category: "\(category).patient")
+    static let task = Logger(subsystem: subsystem, category: "\(category).task")
+    static let outcome = Logger(subsystem: subsystem, category: "\(category).outcome")
+    static let versionable = Logger(subsystem: subsystem, category: "\(category).versionable")
+    static let objectable = Logger(subsystem: subsystem, category: "\(category).objectable")
+    static let pullRevisions = Logger(subsystem: subsystem, category: "\(category).pullRevisions")
+    static let pushRevisions = Logger(subsystem: subsystem, category: "\(category).pushRevisions")
+    static let clock = Logger(subsystem: subsystem, category: "\(category).clock")
+}

--- a/Sources/ParseCareKit/ParseCareKitUtility.swift
+++ b/Sources/ParseCareKit/ParseCareKitUtility.swift
@@ -11,51 +11,55 @@ import ParseSwift
 
 /// Utility functions designed to make things easier.
 public struct ParseCareKitUtility {
-    
+
     /// Can setup a connection to Parse Server based on a ParseCareKit.plist
     public static func setupServer() {
         var propertyListFormat =  PropertyListSerialization.PropertyListFormat.xml
-        var plistConfiguration:[String: AnyObject]
+        var plistConfiguration: [String: AnyObject]
         guard let path = Bundle.main.path(forResource: "ParseCareKit", ofType: "plist"),
-            let xml = FileManager.default.contents(atPath: path) else{
+            let xml = FileManager.default.contents(atPath: path) else {
                 fatalError("Error in ParseCareKit.setupServer(). Can't find ParseCareKit.plist in this project")
         }
-        
-        do{
-            plistConfiguration = try PropertyListSerialization.propertyList(from: xml, options: .mutableContainersAndLeaves, format: &propertyListFormat) as! [String:AnyObject]
-        }catch{
+
+        do {
+            plistConfiguration =
+                try PropertyListSerialization.propertyList(from: xml,
+                                                           options: .mutableContainersAndLeaves,
+                                                           // swiftlint:disable:next force_cast
+                                                           format: &propertyListFormat) as! [String: AnyObject]
+        } catch {
             fatalError("Error in ParseCareKit.setupServer(). Couldn't serialize plist. \(error)")
         }
-        
-        guard let parseDictionary = plistConfiguration["ParseClientConfiguration"] as? [String:AnyObject],
+
+        guard let parseDictionary = plistConfiguration["ParseClientConfiguration"] as? [String: AnyObject],
             let appID = parseDictionary["ApplicationID"] as? String,
             let server = parseDictionary["Server"] as? String,
             let serverURL = URL(string: server),
-            let _ = parseDictionary["EnableLocalDataStore"] as? Bool else {
+            (parseDictionary["EnableLocalDataStore"] as? Bool) != nil else {
                 fatalError("Error in ParseCareKit.setupServer(). Missing keys in \(plistConfiguration)")
         }
-        
+
         ParseSwift.initialize(applicationId: appID, serverURL: serverURL)
     }
-    
+
     /// Converts a date to a String.
-    public static func dateToString(_ date:Date)->String{
-        let dateFormatter:DateFormatter = DateFormatter()
+    public static func dateToString(_ date: Date) -> String {
+        let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-        
+
         return dateFormatter.string(from: date)
     }
-    
+
     /// Converts a String to a Date.
-    public static func stringToDate(_ date:String)->Date?{
-        let dateFormatter:DateFormatter = DateFormatter()
+    public static func stringToDate(_ date: String) -> Date? {
+        let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-        
+
         return dateFormatter.date(from: date)
     }
-    
+
     /// Get the current Parse Encoder with custom date strategy.
     public static func encoder() -> ParseEncoder {
         Note().getEncoder()
@@ -65,7 +69,7 @@ public struct ParseCareKitUtility {
     public static func jsonEncoder() -> JSONEncoder {
         Note().getJSONEncoder()
     }
-    
+
     /// Get the current JSON Decoder with custom date strategy.
     public static func decoder() -> JSONDecoder {
         Note().getDecoder()

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -11,124 +11,143 @@ import CareKitStore
 import ParseSwift
 import os.log
 
+// swiftlint:disable line_length
+
 /**
 Protocol that defines the properties to conform to when updates and conflict resolution is needed.
 */
 public protocol ParseRemoteSynchronizationDelegate: OCKRemoteSynchronizationDelegate {
-    func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void)
+    func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
+                                        completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void)
     func successfullyPushedDataToCloud()
 }
 
 /// Allows the CareKitStore to synchronize against a Parse Server.
 public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
-    
-    public var delegate: OCKRemoteSynchronizationDelegate?
-    
-    /// If set, the delegate will be alerted to important events delivered by the remote store (set this, don't set `delegate`).
+
+    public weak var delegate: OCKRemoteSynchronizationDelegate?
+
+    /// If set, the delegate will be alerted to important events delivered by the remote
+    /// store (set this, don't set `delegate`).
     public var parseRemoteDelegate: ParseRemoteSynchronizationDelegate? {
-        set{
-            parseDelegate = newValue
-            delegate = newValue
-        }get{
+        get {
             return parseDelegate
         }
+        set {
+            parseDelegate = newValue
+            delegate = newValue
+        }
     }
-    
+
     public var automaticallySynchronizes: Bool
-    
+
     /// The unique identifier of the remote clock.
-    public internal(set) var uuid:UUID!
-    
+    public internal(set) var uuid: UUID!
+
     /// A dictionary of any custom classes to synchronize between the CareKitStore and the Parse Server.
-    public internal(set) var customClassesToSynchronize:[String: PCKSynchronizable]?
-    
+    public internal(set) var customClassesToSynchronize: [String: PCKSynchronizable]?
+
     /// A dictionary of any default classes to synchronize between the CareKitStore and the Parse Server. These
     /// are `Patient`, `Task`, `CarePlan`, `Contact`, and `Outcome`.
     public internal(set) var pckStoreClassesToSynchronize: [PCKStoreClass: PCKSynchronizable]!
-    
-    private var parseDelegate: ParseRemoteSynchronizationDelegate?
-    
+
+    private weak var parseDelegate: ParseRemoteSynchronizationDelegate?
+
     /**
      Creates an instance of ParseRemoteSynchronizationManager.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
     */
-    public init(uuid:UUID, auto: Bool) throws {
+    public init(uuid: UUID, auto: Bool) throws {
         self.pckStoreClassesToSynchronize = try PCKStoreClass.patient.getConcrete()
         self.customClassesToSynchronize = nil
         self.uuid = uuid
         self.automaticallySynchronizes = auto
     }
-    
+
     /**
      Creates an instance of ParseRemoteSynchronizationManager.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
-        - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized by passing in the respective Key/Value pairs.
+        - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized
+            by passing in the respective Key/Value pairs.
     */
-    convenience public init(uuid:UUID, auto: Bool, replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable]) throws {
+    convenience public init(uuid: UUID, auto: Bool, replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable]) throws {
         try self.init(uuid: uuid, auto: auto)
-        try self.pckStoreClassesToSynchronize = PCKStoreClass.patient.replaceRemoteConcreteClasses(replacePCKStoreClasses)
+        try self.pckStoreClassesToSynchronize = PCKStoreClass
+            .patient.replaceRemoteConcreteClasses(replacePCKStoreClasses)
         self.customClassesToSynchronize = nil
     }
-    
+
     /**
      Creates an instance of ParseRemoteSynchronizationManager.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
-        - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized by passing in the respective Key/Value pairs. Defaults to nil, which uses the standard default entities.
+        - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized
+            by passing in the respective Key/Value pairs. Defaults to nil, which uses the standard default entities.
         - customClasses: Add custom classes to synchroniz by passing in the respective Key/Value pair.
     */
-    convenience public init(uuid:UUID, auto: Bool, replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable]? = nil, customClasses: [String:PCKSynchronizable]) throws {
+    convenience public init(uuid: UUID, auto: Bool,
+                            replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable]? = nil,
+                            customClasses: [String: PCKSynchronizable]) throws {
         try self.init(uuid: uuid, auto: auto)
-        if replacePCKStoreClasses != nil{
-            self.pckStoreClassesToSynchronize = try PCKStoreClass.patient.replaceRemoteConcreteClasses(replacePCKStoreClasses!)
-        }else{
+        if replacePCKStoreClasses != nil {
+            self.pckStoreClassesToSynchronize = try PCKStoreClass
+                .patient.replaceRemoteConcreteClasses(replacePCKStoreClasses!)
+        } else {
             self.pckStoreClassesToSynchronize = nil
         }
         self.customClassesToSynchronize = customClasses
     }
-    
-    public func pullRevisions(since clock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord, @escaping (Error?) -> Void) -> Void, completion: @escaping (Error?) -> Void) {
-        
-        guard let _ = PCKUser.current else{
+
+    public func pullRevisions(since clock: OCKRevisionRecord.KnowledgeVector,
+                              mergeRevision: @escaping (OCKRevisionRecord, @escaping (Error?) -> Void) -> Void,
+                              completion: @escaping (Error?) -> Void) {
+
+        guard PCKUser.current != nil else {
             let revision = OCKRevisionRecord(entities: [], knowledgeVector: .init())
-            mergeRevision(revision){
-                error in
+            mergeRevision(revision) { error in
                 completion(error)
             }
             return
         }
-        
+
         //Fetch Clock from Cloud
-        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: false){
-            (_, potentialCKClock, error) in
-            guard let cloudVector = potentialCKClock else{
+        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: false) { (_, potentialCKClock, _) in
+            guard let cloudVector = potentialCKClock else {
                 //No Clock available, need to let CareKit know this is the first sync.
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: .init())
-                mergeRevision(revision,completion)
+                mergeRevision(revision, completion)
                 return
             }
-            let returnError:Error? = nil
-            
+            let returnError: Error? = nil
+
             let localClock = clock.clock(for: self.uuid)
-            
-            self.pullRevisionsForConcreteClasses(previousError: returnError, localClock: localClock, cloudVector: cloudVector, mergeRevision: mergeRevision){previosError in
-                    
-                self.pullRevisionsForCustomClasses(previousError: previosError, localClock: localClock, cloudVector: cloudVector, mergeRevision: mergeRevision, completion: completion)
+
+            self.pullRevisionsForConcreteClasses(previousError: returnError, localClock: localClock,
+                                                 cloudVector: cloudVector,
+                                                 mergeRevision: mergeRevision) { previosError in
+
+                self.pullRevisionsForCustomClasses(previousError: previosError, localClock: localClock,
+                                                   cloudVector: cloudVector, mergeRevision: mergeRevision,
+                                                   completion: completion)
             }
         }
     }
-    
-    func pullRevisionsForConcreteClasses(concreteClassesAlreadyPulled:Int=0, previousError: Error?, localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord, @escaping (Error?) -> Void) -> Void, completion: @escaping (Error?) -> Void){
-        
+
+    func pullRevisionsForConcreteClasses(concreteClassesAlreadyPulled: Int=0, previousError: Error?,
+                                         localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector,
+                                         mergeRevision: @escaping (OCKRevisionRecord,
+                                                                   @escaping (Error?) -> Void) -> Void,
+                                         completion: @escaping (Error?) -> Void) {
+
         let classNames = PCKStoreClass.patient.orderedArray()
-        
+
         guard concreteClassesAlreadyPulled < classNames.count,
-            let concreteClass = self.pckStoreClassesToSynchronize[classNames[concreteClassesAlreadyPulled]] else{
+            let concreteClass = self.pckStoreClassesToSynchronize[classNames[concreteClassesAlreadyPulled]] else {
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("Finished pulling revisions for default classes")
                 } else {
@@ -139,29 +158,36 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
         }
         //let newConcreteClass = concreteClass
         var currentError = previousError
-        concreteClass.pullRevisions(since: localClock, cloudClock: cloudVector){
-            customRevision in
-            mergeRevision(customRevision){
-                error in
+        concreteClass.pullRevisions(since: localClock, cloudClock: cloudVector) { customRevision in
+            mergeRevision(customRevision) { error in
                 if error != nil {
                     currentError = error!
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.pullRevisions.error("pullRevisionsForConcreteClasses: \(currentError!.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("pullRevisionsForConcreteClasses: %{private}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
+                        os_log("pullRevisionsForConcreteClasses: %{private}@.",
+                               log: .pullRevisions, type: .error, currentError!.localizedDescription)
                     }
                 }
-                
-                self.pullRevisionsForConcreteClasses(concreteClassesAlreadyPulled: concreteClassesAlreadyPulled+1, previousError: currentError, localClock: localClock, cloudVector: cloudVector, mergeRevision: mergeRevision, completion: completion)
-                
+
+                self.pullRevisionsForConcreteClasses(concreteClassesAlreadyPulled: concreteClassesAlreadyPulled+1,
+                                                     previousError: currentError, localClock: localClock,
+                                                     cloudVector: cloudVector, mergeRevision: mergeRevision,
+                                                     completion: completion)
+
             }
         }
     }
-    
-    func pullRevisionsForCustomClasses(customClassesAlreadyPulled:Int=0, previousError: Error?, localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord, @escaping (Error?) -> Void) -> Void, completion: @escaping (Error?) -> Void){
-        if let customClassesToSynchronize = self.customClassesToSynchronize{
+
+    func pullRevisionsForCustomClasses(customClassesAlreadyPulled: Int=0, previousError: Error?,
+                                       localClock: Int, cloudVector: OCKRevisionRecord.KnowledgeVector,
+                                       mergeRevision: @escaping (OCKRevisionRecord,
+                                                                 @escaping (Error?) -> Void) -> Void,
+                                       completion: @escaping (Error?) -> Void) {
+
+        if let customClassesToSynchronize = self.customClassesToSynchronize {
             let classNames = customClassesToSynchronize.keys.sorted()
-            
+
             guard customClassesAlreadyPulled < classNames.count,
                 let customClass = customClassesToSynchronize[classNames[customClassesAlreadyPulled]] else {
                     if #available(iOS 14.0, watchOS 7.0, *) {
@@ -174,49 +200,51 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     return
             }
             var currentError = previousError
-            customClass.pullRevisions(since: localClock, cloudClock: cloudVector){
-                customRevision in
-                mergeRevision(customRevision){
-                    error in
+            customClass.pullRevisions(since: localClock, cloudClock: cloudVector) { customRevision in
+                mergeRevision(customRevision) { error in
                     if error != nil {
                         currentError = error!
                         if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.pullRevisions.error("pullRevisionsForCustomClasses: \(currentError!.localizedDescription, privacy: .private)")
                         } else {
                             // Fallback on earlier versions
-                            os_log("pullRevisionsForCustomClasses: %{private}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
+                            os_log("pullRevisionsForCustomClasses: %{private}@.",
+                                   log: .pullRevisions, type: .error, currentError!.localizedDescription)
                         }
                     }
-                    
-                    self.pullRevisionsForCustomClasses(customClassesAlreadyPulled: customClassesAlreadyPulled+1, previousError: currentError, localClock: localClock, cloudVector: cloudVector, mergeRevision: mergeRevision, completion: completion)
+
+                    self.pullRevisionsForCustomClasses(customClassesAlreadyPulled: customClassesAlreadyPulled+1,
+                                                       previousError: currentError, localClock: localClock,
+                                                       cloudVector: cloudVector, mergeRevision: mergeRevision,
+                                                       completion: completion)
                 }
             }
-        }else{
+        } else {
             completion(previousError)
         }
     }
-    
-    public func pushRevisions(deviceRevision: OCKRevisionRecord, overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
-        
-        guard let _ = PCKUser.current else{
+
+    public func pushRevisions(deviceRevision: OCKRevisionRecord,
+                              overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+
+        guard PCKUser.current != nil else {
             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
             return
         }
-        
-        guard deviceRevision.entities.count > 0 else{
+
+        guard deviceRevision.entities.count > 0 else {
             //No revisions need to be pushed
             completion(nil)
             return
         }
-        
+
         //Fetch Clock from Cloud
-        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: true){
-            (potentialPCKClock, potentialCKClock, error) in
-        
+        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: true) { (potentialPCKClock, potentialCKClock, error) in
+
             guard let cloudParseVector = potentialPCKClock,
-                let cloudCareKitVector = potentialCKClock else{
-                    
-                    guard let parseError = error else{
+                let cloudCareKitVector = potentialCKClock else {
+
+                    guard let parseError = error else {
                         //There was a different issue that we don't know how to handle
                         if let error = error {
                             if #available(iOS 14.0, watchOS 7.0, *) {
@@ -233,20 +261,21 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                         return
                     }
-                    
-                    switch parseError.code{
-                    case .internalServer, .objectNotFound: //1 - this column hasn't been added. 101 - Query returned no results
-                        if potentialPCKClock != nil{
-                            potentialPCKClock!.save(callbackQueue: .main) {
-                                _ in
+
+                    switch parseError.code {
+                    case .internalServer, .objectNotFound:
+                        //1 - this column hasn't been added. 101 - Query returned no results
+                        if potentialPCKClock != nil {
+                            potentialPCKClock!.save(callbackQueue: .main) { _ in
                                 if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.pushRevisions.error("Saved Clock. Try to sync again \(potentialPCKClock!.localizedDescription, privacy: .private).")
                                 } else {
-                                    os_log("Saved Clock. Try to sync again. %{private}@.", log: .pushRevisions, type: .debug, potentialPCKClock!.localizedDescription)
+                                    os_log("Saved Clock. Try to sync again. %{private}@.",
+                                           log: .pushRevisions, type: .debug, potentialPCKClock!.localizedDescription)
                                 }
                                 completion(error)
                             }
-                        }else{
+                        } else {
                             completion(error)
                         }
                     default:
@@ -260,171 +289,190 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     }
                 return
             }
-            
+
             let cloudVectorClock = cloudCareKitVector.clock(for: self.uuid)
             var revisionsCompletedCount = 0
-            deviceRevision.entities.forEach{
+            deviceRevision.entities.forEach {
                 let entity = $0
-                switch entity{
+                switch entity {
                 case .patient(let patient):
-                    
+
                     if let customClassName = patient.userInfo?[CustomKey.customClass] {
-                        self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        self.pushRevisionForCustomClass(entity, className: customClassName,
+                                                        cloudClock: cloudVectorClock,
+                                                        overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                    }else{
-                        
-                        guard let parse = try? self.pckStoreClassesToSynchronize[.patient]?.new(with: entity) else{
+                    } else {
+
+                        guard let parse = try? self.pckStoreClassesToSynchronize[.patient]?.new(with: entity) else {
                             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
                             return
                         }
-                        
-                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+
+                        parse.pushRevision(cloudClock: cloudVectorClock,
+                                           overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
                     }
-                    
+
                 case .carePlan(let carePlan):
                     if let customClassName = carePlan.userInfo?[CustomKey.customClass] {
-                        self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        self.pushRevisionForCustomClass(entity, className: customClassName,
+                                                        cloudClock: cloudVectorClock,
+                                                        overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                    }else{
-                        
+                    } else {
+
                         guard let parse = try?  self.pckStoreClassesToSynchronize[.carePlan]?.new(with: entity) else {
                             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
                             return
                         }
-                        
-                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+
+                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
                     }
                 case .contact(let contact):
                     if let customClassName = contact.userInfo?[CustomKey.customClass] {
-                        self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        self.pushRevisionForCustomClass(entity, className: customClassName,
+                                                        cloudClock: cloudVectorClock,
+                                                        overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                    }else{
+                    } else {
                         guard let parse = try?  self.pckStoreClassesToSynchronize[.contact]?.new(with: entity) else {
                             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
                             return
                         }
-                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-    
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
                     }
                 case .task(let task):
                     if let customClassName = task.userInfo?[CustomKey.customClass] {
-                        self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        self.pushRevisionForCustomClass(entity, className: customClassName,
+                                                        cloudClock: cloudVectorClock,
+                                                        overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                    }else{
+                    } else {
                         guard let parse = try?  self.pckStoreClassesToSynchronize[.task]?.new(with: entity) else {
                             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
                             return
                         }
-                        
-                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+
+                        parse.pushRevision(cloudClock: cloudVectorClock,
+                                           overwriteRemote: overwriteRemote) { error in
+
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                        
+
                     }
                 case .outcome(let outcome):
-                    
+
                     if let customClassName = outcome.userInfo?[CustomKey.customClass] {
-                        self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        self.pushRevisionForCustomClass(entity, className: customClassName,
+                                                        cloudClock: cloudVectorClock,
+                                                        overwriteRemote: overwriteRemote) { error in
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
-                    }else{
-                        guard let parse = try?  self.pckStoreClassesToSynchronize[.outcome]?.new(with: entity) else{
+                    } else {
+                        guard let parse = try?  self.pckStoreClassesToSynchronize[.outcome]?.new(with: entity) else {
                             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
                             return
                         }
-                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
-                            error in
-                            
+                        parse.pushRevision(cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) { error in
                             if error != nil {
                                 completion(error)
                             }
                             revisionsCompletedCount += 1
-                            if revisionsCompletedCount == deviceRevision.entities.count{
-                                
-                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector, localClock: deviceRevision.knowledgeVector, completion: completion)
+                            if revisionsCompletedCount == deviceRevision.entities.count {
+
+                                self.finishedRevisions(cloudParseVector, cloudClock: cloudCareKitVector,
+                                                       localClock: deviceRevision.knowledgeVector,
+                                                       completion: completion)
                             }
                         }
                     }
@@ -432,56 +480,59 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             }
         }
     }
-    
-    func pushRevisionForCustomClass(_ entity: OCKEntity, className: String, cloudClock: Int, overwriteRemote: Bool, completion: @escaping (Error?) -> Void){
-        guard let customClass = self.customClassesToSynchronize?[className] else{
+
+    func pushRevisionForCustomClass(_ entity: OCKEntity, className: String, cloudClock: Int,
+                                    overwriteRemote: Bool, completion: @escaping (Error?) -> Void) {
+        guard let customClass = self.customClassesToSynchronize?[className] else {
             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
             return
         }
-        
-        guard let parse = try? customClass.new(with: entity) else{
+
+        guard let parse = try? customClass.new(with: entity) else {
             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
             return
         }
-        parse.pushRevision(cloudClock: cloudClock, overwriteRemote: overwriteRemote) {
-            error in
+        parse.pushRevision(cloudClock: cloudClock, overwriteRemote: overwriteRemote) { error in
             completion(error)
         }
     }
-    
-    func finishedRevisions(_ parseClock: Clock, cloudClock: OCKRevisionRecord.KnowledgeVector, localClock: OCKRevisionRecord.KnowledgeVector, completion: @escaping (Error?)->Void){
+
+    func finishedRevisions(_ parseClock: Clock, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                           localClock: OCKRevisionRecord.KnowledgeVector,
+                           completion: @escaping (Error?) -> Void) {
         var parseClock = parseClock
         var cloudVector = cloudClock
         //Increment and merge Knowledge Vector
         cloudVector.increment(clockFor: uuid)
         cloudVector.merge(with: localClock)
-        
-        guard let _ = parseClock.encodeClock(cloudVector) else{
+
+        guard parseClock.encodeClock(cloudVector) != nil else {
             completion(ParseCareKitError.couldntUnwrapClock)
             return
         }
-        parseClock.save(callbackQueue: .main){
-            result in
+        parseClock.save(callbackQueue: .main) { result in
             switch result {
 
-            case .success(_):
+            case .success:
                 self.parseRemoteDelegate?.successfullyPushedDataToCloud()
                 completion(nil)
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pushRevisions.error("finishedRevisions: \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("finishedRevisions: %{private}@.", log: .pushRevisions, type: .error, error.localizedDescription)
+                    os_log("finishedRevisions: %{private}@.",
+                           log: .pushRevisions, type: .error, error.localizedDescription)
                 }
                 completion(error)
             }
         }
     }
-    
-    public func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
-        if parseRemoteDelegate != nil{
+
+    public func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
+                                               completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
+        if parseRemoteDelegate != nil {
             parseRemoteDelegate!.chooseConflictResolutionPolicy(conflict, completion: completion)
-        }else{
+        } else {
             let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
             completion(conflictPolicy)
         }

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -129,7 +129,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
         
         guard concreteClassesAlreadyPulled < classNames.count,
             let concreteClass = self.pckStoreClassesToSynchronize[classNames[concreteClassesAlreadyPulled]] else{
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.debug("Finished pulling revisions for default classes")
                 } else {
                     os_log("Finished pulling revisions for default classes", log: .pullRevisions, type: .debug)
@@ -145,7 +145,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 error in
                 if error != nil {
                     currentError = error!
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.pullRevisions.error("pullRevisionsForConcreteClasses: \(currentError!.localizedDescription)")
                     } else {
                         os_log("pullRevisionsForConcreteClasses: %{public}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
@@ -164,7 +164,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             
             guard customClassesAlreadyPulled < classNames.count,
                 let customClass = customClassesToSynchronize[classNames[customClassesAlreadyPulled]] else {
-                    if #available(iOS 14.0, *) {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.pullRevisions.debug("Finished pulling custom revision classes")
                     } else {
                         // Fallback on earlier versions
@@ -180,7 +180,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     error in
                     if error != nil {
                         currentError = error!
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.pullRevisions.error("pullRevisionsForCustomClasses: \(currentError!.localizedDescription)")
                         } else {
                             // Fallback on earlier versions
@@ -219,13 +219,13 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     guard let parseError = error else{
                         //There was a different issue that we don't know how to handle
                         if let error = error {
-                            if #available(iOS 14.0, *) {
+                            if #available(iOS 14.0, watchOS 7.0, *) {
                                 Logger.pushRevisions.error("\(error.localizedDescription)")
                             } else {
                                 os_log("%{public}@.", log: .pushRevisions, type: .error, error.localizedDescription)
                             }
                         } else {
-                            if #available(iOS 14.0, *) {
+                            if #available(iOS 14.0, watchOS 7.0, *) {
                                 Logger.pushRevisions.error("Error in pushRevisions.")
                             } else {
                                 os_log("Error in pushRevisions.", log: .pushRevisions, type: .error)
@@ -239,7 +239,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         if potentialPCKClock != nil{
                             potentialPCKClock!.save(callbackQueue: .main) {
                                 _ in
-                                if #available(iOS 14.0, *) {
+                                if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.pushRevisions.error("Error in pushRevisions.")
                                 } else {
                                     os_log("Saved Clock. Try to sync again. %{public}@.", log: .pushRevisions, type: .debug, potentialPCKClock! as! CVarArg)
@@ -251,7 +251,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                     default:
                         //There was a different issue that we don't know how to handle
-                        if #available(iOS 14.0, *) {
+                        if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.pushRevisions.error("\(parseError.localizedDescription)")
                         } else {
                             os_log("%{public}@.", log: .pushRevisions, type: .error, parseError.localizedDescription)
@@ -468,7 +468,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 self.parseRemoteDelegate?.successfullyPushedDataToCloud()
                 completion(nil)
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pushRevisions.error("finishedRevisions: \(error.localizedDescription)")
                 } else {
                     os_log("finishedRevisions: %{public}@.", log: .pushRevisions, type: .error, error.localizedDescription)

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -42,14 +42,14 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
     public var automaticallySynchronizes: Bool
 
     /// The unique identifier of the remote clock.
-    public internal(set) var uuid: UUID!
+    public var uuid: UUID!
 
     /// A dictionary of any custom classes to synchronize between the CareKitStore and the Parse Server.
-    public internal(set) var customClassesToSynchronize: [String: PCKSynchronizable]?
+    public var customClassesToSynchronize: [String: PCKSynchronizable]?
 
     /// A dictionary of any default classes to synchronize between the CareKitStore and the Parse Server. These
     /// are `Patient`, `Task`, `CarePlan`, `Contact`, and `Outcome`.
-    public internal(set) var pckStoreClassesToSynchronize: [PCKStoreClass: PCKSynchronizable]!
+    public var pckStoreClassesToSynchronize: [PCKStoreClass: PCKSynchronizable]!
 
     private weak var parseDelegate: ParseRemoteSynchronizationDelegate?
 

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -146,9 +146,9 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 if error != nil {
                     currentError = error!
                     if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.pullRevisions.error("pullRevisionsForConcreteClasses: \(currentError!.localizedDescription)")
+                        Logger.pullRevisions.error("pullRevisionsForConcreteClasses: \(currentError!.localizedDescription, privacy: .private)")
                     } else {
-                        os_log("pullRevisionsForConcreteClasses: %{public}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
+                        os_log("pullRevisionsForConcreteClasses: %{private}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
                     }
                 }
                 
@@ -181,10 +181,10 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     if error != nil {
                         currentError = error!
                         if #available(iOS 14.0, watchOS 7.0, *) {
-                            Logger.pullRevisions.error("pullRevisionsForCustomClasses: \(currentError!.localizedDescription)")
+                            Logger.pullRevisions.error("pullRevisionsForCustomClasses: \(currentError!.localizedDescription, privacy: .private)")
                         } else {
                             // Fallback on earlier versions
-                            os_log("pullRevisionsForCustomClasses: %{public}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
+                            os_log("pullRevisionsForCustomClasses: %{private}@.", log: .pullRevisions, type: .error, currentError!.localizedDescription)
                         }
                     }
                     
@@ -220,9 +220,9 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         //There was a different issue that we don't know how to handle
                         if let error = error {
                             if #available(iOS 14.0, watchOS 7.0, *) {
-                                Logger.pushRevisions.error("\(error.localizedDescription)")
+                                Logger.pushRevisions.error("\(error.localizedDescription, privacy: .private)")
                             } else {
-                                os_log("%{public}@.", log: .pushRevisions, type: .error, error.localizedDescription)
+                                os_log("%{private}@.", log: .pushRevisions, type: .error, error.localizedDescription)
                             }
                         } else {
                             if #available(iOS 14.0, watchOS 7.0, *) {
@@ -240,9 +240,9 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                             potentialPCKClock!.save(callbackQueue: .main) {
                                 _ in
                                 if #available(iOS 14.0, watchOS 7.0, *) {
-                                    Logger.pushRevisions.error("Error in pushRevisions.")
+                                    Logger.pushRevisions.error("Saved Clock. Try to sync again \(potentialPCKClock!.localizedDescription, privacy: .private).")
                                 } else {
-                                    os_log("Saved Clock. Try to sync again. %{public}@.", log: .pushRevisions, type: .debug, potentialPCKClock! as! CVarArg)
+                                    os_log("Saved Clock. Try to sync again. %{private}@.", log: .pushRevisions, type: .debug, potentialPCKClock!.localizedDescription)
                                 }
                                 completion(error)
                             }
@@ -252,9 +252,9 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     default:
                         //There was a different issue that we don't know how to handle
                         if #available(iOS 14.0, watchOS 7.0, *) {
-                            Logger.pushRevisions.error("\(parseError.localizedDescription)")
+                            Logger.pushRevisions.error("\(parseError.localizedDescription, privacy: .private)")
                         } else {
-                            os_log("%{public}@.", log: .pushRevisions, type: .error, parseError.localizedDescription)
+                            os_log("%{private}@.", log: .pushRevisions, type: .error, parseError.localizedDescription)
                         }
                         completion(error)
                     }
@@ -469,9 +469,9 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 completion(nil)
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.pushRevisions.error("finishedRevisions: \(error.localizedDescription)")
+                    Logger.pushRevisions.error("finishedRevisions: \(error.localizedDescription, privacy: .private)")
                 } else {
-                    os_log("finishedRevisions: %{public}@.", log: .pushRevisions, type: .error, error.localizedDescription)
+                    os_log("finishedRevisions: %{private}@.", log: .pushRevisions, type: .error, error.localizedDescription)
                 }
                 completion(error)
             }

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -268,7 +268,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 switch entity{
                 case .patient(let patient):
                     
-                    if let customClassName = patient.userInfo?[kPCKCustomClassKey] {
+                    if let customClassName = patient.userInfo?[CustomKey.customClass] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
                             error in
                             
@@ -301,7 +301,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     }
                     
                 case .carePlan(let carePlan):
-                    if let customClassName = carePlan.userInfo?[kPCKCustomClassKey] {
+                    if let customClassName = carePlan.userInfo?[CustomKey.customClass] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
                             error in
                             
@@ -333,7 +333,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                     }
                 case .contact(let contact):
-                    if let customClassName = contact.userInfo?[kPCKCustomClassKey] {
+                    if let customClassName = contact.userInfo?[CustomKey.customClass] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
                             error in
                             
@@ -364,7 +364,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         }
                     }
                 case .task(let task):
-                    if let customClassName = task.userInfo?[kPCKCustomClassKey] {
+                    if let customClassName = task.userInfo?[CustomKey.customClass] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
                             error in
                             
@@ -398,7 +398,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                     }
                 case .outcome(let outcome):
                     
-                    if let customClassName = outcome.userInfo?[kPCKCustomClassKey] {
+                    if let customClassName = outcome.userInfo?[CustomKey.customClass] {
                         self.pushRevisionForCustomClass(entity, className: customClassName, cloudClock: cloudVectorClock, overwriteRemote: overwriteRemote) {
                             error in
                             

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -140,8 +140,8 @@ extension PCKObjectable {
             return
         }
              
-        let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .include([kPCKObjectableNotesKey])
+        let query = Self.query(ObjectableKey.uuid == uuidString)
+            .include([ObjectableKey.notes])
         query.first(callbackQueue: .main) { result in
             
             switch result {
@@ -177,8 +177,8 @@ extension PCKObjectable {
                 return
         }
             
-        let query = Self.query(kPCKObjectableUUIDKey == uuidString)
-            .include([kPCKObjectableNotesKey])
+        let query = Self.query(ObjectableKey.uuid == uuidString)
+            .include([ObjectableKey.notes])
         query.find(callbackQueue: .main){
             results in
             

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -11,62 +11,65 @@ import ParseSwift
 import CareKitStore
 import os.log
 
+// swiftlint:disable line_length
+// swiftlint:disable identifier_name
+
 internal protocol PCKObjectable: ParseObject, CustomStringConvertible {
     /// A universally unique identifier for this object.
     var uuid: UUID? {get set}
 
     /// A human readable unique identifier. It is used strictly by the developer and will never be shown to a user
-    var id:String { get }
-    
+    var id: String { get }
+
     /// A human readable unique identifier (same as `id`, but this is what's on the Parse server, `id` is
     /// already taken in Parse). It is used strictly by the developer and will never be shown to a user
     var entityId: String? {get set}
-    
+
     // The clock value of when this object was added to the Parse server.
     var logicalClock: Int? {get set}
-    
+
     /// The semantic version of the database schema when this object was created.
     /// The value will be nil for objects that have not yet been persisted.
     var schemaVersion: OCKSemanticVersion? {get set}
-    
+
     /// The date at which the object was first persisted to the database.
     /// It will be nil for unpersisted values and objects.
     var createdDate: Date? {get set}
-    
+
     /// The last date at which the object was updated.
     /// It will be nil for unpersisted values and objects.
     var updatedDate: Date? {get set}
-    
+
     /// The timezone this record was created in.
     var timezone: TimeZone? {get set}
-    
+
     /// A dictionary of information that can be provided by developers to support their own unique
     /// use cases.
     var userInfo: [String: String]? {get set}
-    
+
     /// A user-defined group identifier that can be used both for querying and sorting results.
     /// Examples may include: "medications", "exercises", "family", "males", "diabetics", etc.
     var groupIdentifier: String? {get set}
-    
+
     /// An array of user-defined tags that can be used to sort or classify objects or values.
     var tags: [String]? {get set}
-    
+
     /// Specifies where this object originated from. It could contain information about the device
     /// used to record the data, its software version, or the person who recorded the data.
     var source: String? {get set}
-    
+
     /// Specifies the location of some asset associated with this object. It could be the URL for
     /// an image or video, the bundle name of a audio asset, or any other representation the
     /// developer chooses.
     var asset: String? {get set}
-    
+
     /// Any array of notes associated with this object.
     var notes: [Note]? {get set}
-    
+
     /// A unique id optionally used by a remote database. Its precise format will be
     /// determined by the remote database, but it is generally not expected to be human readable.
     var remoteID: String? {get set}
-    
+
     /// A boolean that is `true` when encoding the object for Parse. If `false` the object is encoding for CareKit.
     var encodingForParse: Bool {get set}
 
@@ -81,7 +84,7 @@ extension PCKObjectable {
         Note.replaceWithCloudVersion(&current.notes, cloud: parse.notes)
         return current
     }
-    
+
     /// Copies the common values of another PCKObjectable object.
     /// - parameter from: The PCKObjectable object to copy from.
     mutating public func copyCommonValues(from other: Self) {
@@ -106,13 +109,13 @@ extension PCKObjectable {
         guard let logicalClock = self.logicalClock else {
             throw ParseCareKitError.cantUnwrapSelf
         }
-        self.notes?.forEach{$0.stamp(logicalClock)}
+        self.notes?.forEach {$0.stamp(logicalClock)}
         return self
     }
 
     /// Determines if this PCKObjectable object can be converted to CareKit
     public func canConvertToCareKit() -> Bool {
-        guard let _ = self.entityId else {
+        guard self.entityId != nil else {
             return false
         }
         return true
@@ -126,35 +129,35 @@ extension PCKObjectable {
         - completion: The block to execute.
      It should have the following argument signature: `(Result<Self,Error>)`.
     */
-    static public func first(_ uuid:UUID?, relatedObject:Self?=nil, completion: @escaping(Result<Self,Error>) -> Void) {
-          
-        guard let _ = PCKUser.current,
-            let uuidString = uuid?.uuidString else{
+    static public func first(_ uuid: UUID?, relatedObject: Self?=nil, completion: @escaping(Result<Self, Error>) -> Void) {
+
+        guard PCKUser.current != nil,
+            let uuidString = uuid?.uuidString else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
                 return
         }
-            
-        guard relatedObject == nil else{
+
+        guard relatedObject == nil else {
             //No need to query the Cloud, it's already present
             completion(.success(relatedObject!))
             return
         }
-             
+
         let query = Self.query(ObjectableKey.uuid == uuidString)
             .include([ObjectableKey.notes])
         query.first(callbackQueue: .main) { result in
-            
+
             switch result {
-            
+
             case .success(let object):
                 completion(.success(object))
             case .failure(let error):
                 completion(.failure(error))
             }
-            
+
         }
     }
-    
+
     /**
      Finds all objects on the server that has the same `uuid`.
      - Parameters:
@@ -162,42 +165,44 @@ extension PCKObjectable {
         - completion: The block to execute.
      It should have the following argument signature: `(Result<Self,Error>)`.
     */
-    public func find(_ uuid:UUID?,
-                         completion: @escaping(Result<[Self],Error>) -> Void) {
-          
-        guard let _ = PCKUser.current,
+    public func find(_ uuid: UUID?,
+                     completion: @escaping(Result<[Self], Error>) -> Void) {
+
+        guard PCKUser.current != nil,
             let uuidString = uuid?.uuidString else {
 
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.objectable.error("\(self.className, privacy: .private).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription, privacy: .private).")
             } else {
-                os_log("%{private}@.find(), : %{private}@", log: .objectable, type: .error, self.className, ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription)
+                os_log("%{private}@.find(), : %{private}@",
+                       log: .objectable, type: .error, self.className,
+                       ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription)
             }
             completion(.failure(ParseCareKitError.couldntUnwrapClock))
                 return
         }
-            
+
         let query = Self.query(ObjectableKey.uuid == uuidString)
             .include([ObjectableKey.notes])
-        query.find(callbackQueue: .main){
-            results in
-            
+        query.find(callbackQueue: .main) { results in
+
             switch results {
-            
+
             case .success(let foundObjects):
                 completion(.success(foundObjects))
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.objectable.error("\(self.className, privacy: .private).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription, privacy: .private). UUID: \(uuid!, privacy: .private)")
                 } else {
-                    os_log("%{private}@.find(), %{private}@. UUID: %{private}@", log: .objectable, type: .error, self.className, error.localizedDescription, uuidString)
+                    os_log("%{private}@.find(), %{private}@. UUID: %{private}@",
+                           log: .objectable, type: .error, self.className, error.localizedDescription, uuidString)
                 }
                 completion(.failure(error))
             }
-            
+
         }
     }
-    
+
     /**
      Create a `DateInterval` like how CareKit generates one.
      - Parameters:
@@ -237,7 +242,7 @@ extension PCKObjectable {
 
 //Encodable
 extension PCKObjectable {
-    
+
     /**
      Encodes the PCKObjectable properties of the object
      - Parameters:
@@ -245,7 +250,7 @@ extension PCKObjectable {
     */
     public func encodeObjectable(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: PCKCodingKeys.self)
-        
+
         if encodingForParse {
             if !(self is Note) || !(self is OutcomeValue) {
                 try container.encodeIfPresent(entityId, forKey: .entityId)

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -14,7 +14,7 @@ import os.log
 // swiftlint:disable line_length
 // swiftlint:disable identifier_name
 
-internal protocol PCKObjectable: ParseObject, CustomStringConvertible {
+public protocol PCKObjectable: ParseObject, CustomStringConvertible {
     /// A universally unique identifier for this object.
     var uuid: UUID? {get set}
 

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -168,7 +168,7 @@ extension PCKObjectable {
         guard let _ = PCKUser.current,
             let uuidString = uuid?.uuidString else {
 
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.objectable.error("\(self.className).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription).")
             } else {
                 os_log("%{public}@.find(), : %{public}@", log: .objectable, type: .error, self.className, ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription)
@@ -187,7 +187,7 @@ extension PCKObjectable {
             case .success(let foundObjects):
                 completion(.success(foundObjects))
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.objectable.error("\(self.className).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription). UUID: \(uuid!, privacy: .private)")
                 } else {
                     os_log("%{public}@.find(), %{public}@. UUID: %{private}@", log: .objectable, type: .error, self.className, error.localizedDescription, uuidString)

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -228,10 +228,10 @@ extension PCKObjectable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.uuid)
     }
-    
+
     //CustomStringConvertible
     public var description: String {
-        "className=\(className) uuid=\(String(describing: uuid)) id=\(id) createdDate=\(String(describing: createdDate)) updatedDate=\(String(describing: updatedDate)) timezone=\(String(describing: timezone)) objectId=\(String(describing: objectId)) createdAt=\(String(describing: createdAt)) updatedAt=\(String(describing: updatedAt)) logicalClock=\(String(describing: logicalClock)) encodingForParse=\(encodingForParse) ACL=\(String(describing: ACL))"
+        "className=\(className) uuid=\(String(describing: uuid)) id=\(id) createdDate=\(String(describing: createdDate)) updatedDate=\(String(describing: updatedDate)) schemaVersion=\(String(describing: schemaVersion))  timezone=\(String(describing: timezone)) userInfo=\(String(describing: userInfo)) groupIdentifier=\(String(describing: groupIdentifier)) tags=\(String(describing: tags)) source=\(String(describing: source)) asset=\(String(describing: asset)) remoteID=\(String(describing: remoteID)) notes=\(String(describing: notes)) objectId=\(String(describing: objectId)) createdAt=\(String(describing: createdAt)) updatedAt=\(String(describing: updatedAt)) logicalClock=\(String(describing: logicalClock)) encodingForParse=\(encodingForParse) ACL=\(String(describing: ACL))"
     }
 }
 

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -169,9 +169,9 @@ extension PCKObjectable {
             let uuidString = uuid?.uuidString else {
 
             if #available(iOS 14.0, watchOS 7.0, *) {
-                Logger.objectable.error("\(self.className).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription).")
+                Logger.objectable.error("\(self.className, privacy: .private).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription, privacy: .private).")
             } else {
-                os_log("%{public}@.find(), : %{public}@", log: .objectable, type: .error, self.className, ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription)
+                os_log("%{private}@.find(), : %{private}@", log: .objectable, type: .error, self.className, ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription)
             }
             completion(.failure(ParseCareKitError.couldntUnwrapClock))
                 return
@@ -188,9 +188,9 @@ extension PCKObjectable {
                 completion(.success(foundObjects))
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.objectable.error("\(self.className).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription). UUID: \(uuid!, privacy: .private)")
+                    Logger.objectable.error("\(self.className, privacy: .private).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription, privacy: .private). UUID: \(uuid!, privacy: .private)")
                 } else {
-                    os_log("%{public}@.find(), %{public}@. UUID: %{private}@", log: .objectable, type: .error, self.className, error.localizedDescription, uuidString)
+                    os_log("%{private}@.find(), %{private}@. UUID: %{private}@", log: .objectable, type: .error, self.className, error.localizedDescription, uuidString)
                 }
                 completion(.failure(error))
             }

--- a/Sources/ParseCareKit/Protocols/PCKSynchronizable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKSynchronizable.swift
@@ -14,25 +14,27 @@ import CareKitStore
  Objects that conform to the `PCKSynchronizable` protocol are synchronized between the OCKStore and the Parse Cloud.
 */
 public protocol PCKSynchronizable {
-    
+
     /**
-     Adds an object that conforms to PCKSynchronizable to the Parse Server and keeps it synchronized with the CareKitStore.
+     Adds an object that conforms to PCKSynchronizable to the Parse Server and keeps
+     it synchronized with the CareKitStore.
 
      - parameter overwriteRemote: Whether data should be overwritten if it's already present on the Parse Server.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<PCKSynchronizable,Error>)`.
     */
-    func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable,Error>) -> Void)
-    
+    func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void)
+
     /**
-     Updates an object that conforms to PCKSynchronizable that is already on the Parse Server and keeps it synchronized with the CareKitStore.
+     Updates an object that conforms to PCKSynchronizable that is already on the Parse
+     Server and keeps it synchronized with the CareKitStore.
 
      - parameter overwriteRemote: Whether data should be overwritten if it's already present on the Parse Server.
      - parameter completion: The block to execute.
      It should have the following argument signature: `(Result<PCKSynchronizable,Error>)`.
     */
-    func updateCloud(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void)
-    
+    func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void)
+
     /**
      Creates a new ParseCareKit object from a specified CareKit entity.
 
@@ -41,7 +43,7 @@ public protocol PCKSynchronizable {
      - returns: Returns a new version of `Self`
     */
     func new(with careKitEntity: OCKEntity) throws -> Self
-    
+
     /**
      Fetch all objects from the server that have been made on since the last time synchronization was performed.
 
@@ -54,8 +56,8 @@ public protocol PCKSynchronizable {
        Wait until one merge has completed before starting another.
      
     */
-    func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector, mergeRevision: @escaping (OCKRevisionRecord) -> Void)
-    
+    func pullRevisions(since localClock: Int, cloudClock: OCKRevisionRecord.KnowledgeVector,
+                       mergeRevision: @escaping (OCKRevisionRecord) -> Void)
 
     /**
      Push a revision from a device up to the server.

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ParseSwift
+import os.log
 
 internal protocol PCKVersionable: PCKObjectable, PCKSynchronizable {
     /// The UUID of the previous version of this object, or nil if there is no previous version.
@@ -113,14 +114,22 @@ extension PCKVersionable {
                                         case .success(_):
                                             self.fixVersionLinkedList(previousFound, backwards: backwards)
                                         case .failure(let error):
-                                            print("Couldn't save in fixVersionLinkedList(). Error: \(error). Object: \(versionFixed)")
+                                            if #available(iOS 14.0, *) {
+                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                            } else {
+                                                os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                            }
                                         }
                                     }
                                 }else{
                                     self.fixVersionLinkedList(previousFound, backwards: backwards)
                                 }
                             case .failure(let error):
-                                print("Couldn't save in fixVersionLinkedList(). Error: \(error). Object: \(versionFixed)")
+                                if #available(iOS 14.0, *) {
+                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                } else {
+                                    os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                }
                             }
                         }
 
@@ -152,14 +161,22 @@ extension PCKVersionable {
                                         case .success(_):
                                             self.fixVersionLinkedList(nextFound, backwards: backwards)
                                         case .failure(let error):
-                                            print("Couldn't save in fixVersionLinkedList(). Error: \(error). Object: \(versionFixed)")
+                                            if #available(iOS 14.0, *) {
+                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                            } else {
+                                                os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                            }
                                         }
                                     }
                                 }else{
                                     self.fixVersionLinkedList(nextFound, backwards: backwards)
                                 }
                             case .failure(let error):
-                                print("Couldn't save in fixVersionLinkedList(). Error: \(error). Object: \(versionFixed)")
+                                if #available(iOS 14.0, *) {
+                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                } else {
+                                    os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                }
                             }
                         }
                     case .failure(_):
@@ -184,7 +201,11 @@ extension PCKVersionable {
             switch results {
             
             case .success(let savedObject):
-                print("Successfully added \(savedObject) to Cloud")
+                if #available(iOS 14.0, *) {
+                    Logger.versionable.debug("Successfully added to cloud: \(savedObject, privacy: .private)")
+                } else {
+                    os_log("Successfully added to cloud: %{private}@", log: .versionable, type: .debug, savedObject.description)
+                }
                 
                 self.linkVersions { result in
                     
@@ -211,11 +232,19 @@ extension PCKVersionable {
                                             case .success(_):
                                                 self.fixVersionLinkedList(previousObjectFound, backwards: true)
                                             case .failure(let error):
-                                                print("Couldn't save(). Error: \(error). Object: \(self)")
+                                                if #available(iOS 14.0, *) {
+                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                                } else {
+                                                    os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                }
                                             }
                                         }
                                     case .failure(let error):
-                                        print("Couldn't find object in save(). Error: \(error). Object: \(self)")
+                                        if #available(iOS 14.0, *) {
+                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                        } else {
+                                            os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                        }
                                     }
                                 }
                             }
@@ -239,11 +268,19 @@ extension PCKVersionable {
                                             case .success(_):
                                                 self.fixVersionLinkedList(nextObjectFound, backwards: true)
                                             case .failure(let error):
-                                                print("Couldn't save(). Error: \(error). Object: \(self)")
+                                                if #available(iOS 14.0, *) {
+                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                                } else {
+                                                    os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                }
                                             }
                                         }
                                     case .failure(let error):
-                                        print("Couldn't find object in save(). Error: \(error). Object: \(self)")
+                                        if #available(iOS 14.0, *) {
+                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                        } else {
+                                            os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                        }
                                     }
                                 }
                             }
@@ -254,7 +291,11 @@ extension PCKVersionable {
                 completion(.success(savedObject))
 
             case .failure(let error):
-                print("Error in \(versionedObject.className).save(). \(String(describing: error))")
+                if #available(iOS 14.0, *) {
+                    Logger.versionable.error("\(versionedObject.className).save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                } else {
+                    os_log("%{public}@.save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, versionedObject.className, error.localizedDescription, versionedObject.description)
+                }
                 completion(.failure(error))
             }
         }

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -14,7 +14,7 @@ import os.log
 // swiftlint:disable cyclomatic_complexity
 // swiftlint:disable function_body_length
 
-internal protocol PCKVersionable: PCKObjectable, PCKSynchronizable {
+public protocol PCKVersionable: PCKObjectable, PCKSynchronizable {
     /// The UUID of the previous version of this object, or nil if there is no previous version.
     var previousVersionUUID: UUID? { get set }
 

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -307,18 +307,18 @@ extension PCKVersionable {
         let interval = createCurrentDateInterval(for: date)
     
         let query = queryToAndWith
-            .where(doesNotExist(key: kPCKObjectableDeletedDateKey)) //Only consider non deleted keys
-            .where(kPCKVersionedObjectEffectiveDateKey < interval.end)
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+            .where(doesNotExist(key: VersionableKey.deletedDate)) //Only consider non deleted keys
+            .where(VersionableKey.effectiveDate < interval.end)
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         return query
     }
     
     private static func queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for date: Date)-> Query<Self> {
         
-        let query = Self.query(doesNotExist(key: kPCKVersionedObjectNextKey))
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+        let query = Self.query(doesNotExist(key: VersionableKey.next))
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         let interval = createCurrentDateInterval(for: date)
-        let greaterEqualEffectiveDate = self.query(kPCKVersionedObjectEffectiveDateKey >= interval.end)
+        let greaterEqualEffectiveDate = self.query(VersionableKey.effectiveDate >= interval.end)
         return Self.query(or(queries: [query,greaterEqualEffectiveDate]))
     }
     
@@ -336,7 +336,7 @@ extension PCKVersionable {
     //This query doesn't filter nextVersion effectiveDate >= interval.end
     public static func query(for date: Date) -> Query<Self> {
         let query = queryVersion(for: date, queryToAndWith: queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for: date))
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         return query
     }
 
@@ -349,7 +349,7 @@ extension PCKVersionable {
     */
     public func find(for date: Date, completion: @escaping(Result<[Self],ParseError>) -> Void) {
         let query = Self.query(for: date)
-            .include([kPCKVersionedObjectNextKey, kPCKVersionedObjectPreviousKey, kPCKObjectableNotesKey])
+            .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main) { results in
             switch results {
             

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -10,19 +10,23 @@ import Foundation
 import ParseSwift
 import os.log
 
+// swiftlint:disable line_length
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable function_body_length
+
 internal protocol PCKVersionable: PCKObjectable, PCKSynchronizable {
     /// The UUID of the previous version of this object, or nil if there is no previous version.
     var previousVersionUUID: UUID? { get set }
 
     /// The previous version of this object, or nil if there is no previous version.
     var previousVersion: Self? { get set }
-    
+
     /// The UUID of the next version of this object, or nil if there is no next version.
     var nextVersionUUID: UUID? { get set }
 
     /// The next version of this object, or nil if there is no next version.
     var nextVersion: Self? { get set }
-    
+
     /// The date that this version of the object begins to take precedence over the previous version.
     /// Often this will be the same as the `createdDate`, but is not required to be.
     var effectiveDate: Date? { get set }
@@ -53,30 +57,30 @@ extension PCKVersionable {
         - completion: The block to execute.
      It should have the following argument signature: `(Result<Self,Error>)`.
     */
-    func linkVersions(completion: @escaping (Result<Self,Error>) -> Void) {
+    func linkVersions(completion: @escaping (Result<Self, Error>) -> Void) {
         var versionedObject = self
         Self.first(versionedObject.previousVersionUUID, relatedObject: versionedObject.previousVersion) { result in
-            
+
             switch result {
-            
+
             case .success(let previousObject):
-                
+
                 versionedObject.previousVersion = previousObject
-                
+
                 Self.first(versionedObject.nextVersionUUID, relatedObject: versionedObject.nextVersion) { result in
-                    
+
                     switch result {
-                    
+
                     case .success(let nextObject):
 
                         versionedObject.nextVersion = nextObject
                         completion(.success(versionedObject))
-                        
-                    case .failure(_):
+
+                    case .failure:
                         completion(.success(versionedObject))
                     }
                 }
-                
+
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -89,96 +93,104 @@ extension PCKVersionable {
         - versionFixed: An object that has been,
         - backwards: The direction in which the link list is being traversed. `true` is backwards, `false` is forwards.
     */
-    func fixVersionLinkedList(_ versionFixed: Self, backwards:Bool){
+    func fixVersionLinkedList(_ versionFixed: Self, backwards: Bool) {
         var versionFixed = versionFixed
-        
-        if backwards{
-            if versionFixed.previousVersionUUID != nil && versionFixed.previousVersion == nil{
+
+        if backwards {
+            if versionFixed.previousVersionUUID != nil && versionFixed.previousVersion == nil {
                 Self.first(versionFixed.previousVersionUUID, relatedObject: versionFixed.previousVersion) { result in
 
                     switch result {
-                    
+
                     case .success(var previousFound):
-                        
+
                         versionFixed.previousVersion = previousFound
                         versionFixed.save(callbackQueue: .main) { results in
                             switch results {
-                            
-                            case .success(_):
-                                if previousFound.nextVersion == nil{
+
+                            case .success:
+                                if previousFound.nextVersion == nil {
                                     previousFound.nextVersion = versionFixed
-                                    previousFound.save(callbackQueue: .main){ results in
+                                    previousFound.save(callbackQueue: .main) { results in
                                         switch results {
-                                        
-                                        case .success(_):
+
+                                        case .success:
                                             self.fixVersionLinkedList(previousFound, backwards: backwards)
                                         case .failure(let error):
                                             if #available(iOS 14.0, watchOS 7.0, *) {
                                                 Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                             } else {
-                                                os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                                os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@",
+                                                       log: .versionable, type: .error,
+                                                       error.localizedDescription, versionFixed.description)
                                             }
                                         }
                                     }
-                                }else{
+                                } else {
                                     self.fixVersionLinkedList(previousFound, backwards: backwards)
                                 }
                             case .failure(let error):
                                 if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                 } else {
-                                    os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                    os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@",
+                                           log: .versionable, type: .error,
+                                           error.localizedDescription, versionFixed.description)
                                 }
                             }
                         }
 
-                    case .failure(_):
+                    case .failure:
                         return
                     }
                 }
             }
             //We are done fixing
-        }else{
-            if versionFixed.nextVersionUUID != nil && versionFixed.nextVersion == nil{
+        } else {
+            if versionFixed.nextVersionUUID != nil && versionFixed.nextVersion == nil {
                 Self.first(versionFixed.nextVersionUUID, relatedObject: versionFixed.nextVersion) { result in
-                    
+
                     switch result {
-                    
+
                     case .success(var nextFound):
-                        
+
                         versionFixed.nextVersion = nextFound
-                        versionFixed.save(callbackQueue: .main){ results in
+                        versionFixed.save(callbackQueue: .main) { results in
                             switch results {
-                            
-                            case .success(_):
-                                if nextFound.previousVersion == nil{
+
+                            case .success:
+                                if nextFound.previousVersion == nil {
                                     nextFound.previousVersion = versionFixed
-                                    nextFound.save(callbackQueue: .main){ results in
-                                    
+                                    nextFound.save(callbackQueue: .main) { results in
+
                                         switch results {
-                                        
-                                        case .success(_):
+
+                                        case .success:
                                             self.fixVersionLinkedList(nextFound, backwards: backwards)
                                         case .failure(let error):
                                             if #available(iOS 14.0, watchOS 7.0, *) {
                                                 Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                             } else {
-                                                os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                                os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@",
+                                                       log: .versionable, type: .error,
+                                                       error.localizedDescription, versionFixed.description)
                                             }
                                         }
                                     }
-                                }else{
+                                } else {
                                     self.fixVersionLinkedList(nextFound, backwards: backwards)
                                 }
                             case .failure(let error):
                                 if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                 } else {
-                                    os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                    os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@",
+                                           log: .versionable, type: .error,
+                                           error.localizedDescription, versionFixed.description)
                                 }
                             }
                         }
-                    case .failure(_):
+                    case .failure:
                         return
                     }
                 }
@@ -193,48 +205,50 @@ extension PCKVersionable {
         - completion: The block to execute.
      It should have the following argument signature: `(Result<PCKSynchronizable,Error>)`.
     */
-    public func save(completion: @escaping(Result<PCKSynchronizable,Error>) -> Void) {
+    public func save(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
         var versionedObject = self
         _ = try? versionedObject.stampRelationalEntities()
-        versionedObject.save(callbackQueue: .main){ results in
+        versionedObject.save(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let savedObject):
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.versionable.debug("Successfully added to cloud: \(savedObject, privacy: .private)")
                 } else {
-                    os_log("Successfully added to cloud: %{private}@", log: .versionable, type: .debug, savedObject.description)
+                    os_log("Successfully added to cloud: %{private}@",
+                           log: .versionable, type: .debug, savedObject.description)
                 }
-                
+
                 self.linkVersions { result in
-                    
+
                     if case let .success(modifiedObject) = result {
 
                         modifiedObject.save(callbackQueue: .main) { _ in }
-                        
+
                         //Fix versioning doubly linked list if it's broken in the cloud
                         if modifiedObject.previousVersion != nil {
                             if modifiedObject.previousVersion!.nextVersion == nil {
-                                modifiedObject.previousVersion!.find(modifiedObject.previousVersion!.uuid) {
-                                    results in
-                                    
+                                modifiedObject.previousVersion!.find(modifiedObject.previousVersion!.uuid) { results in
+
                                     switch results {
-                                    
+
                                     case .success(let versionedObjectsFound):
                                         guard var previousObjectFound = versionedObjectsFound.first else {
                                             return
                                         }
                                         previousObjectFound.nextVersion = modifiedObject
-                                        previousObjectFound.save(callbackQueue: .main){ results in
+                                        previousObjectFound.save(callbackQueue: .main) { results in
                                             switch results {
-                                                
-                                            case .success(_):
+
+                                            case .success:
                                                 self.fixVersionLinkedList(previousObjectFound, backwards: true)
                                             case .failure(let error):
                                                 if #available(iOS 14.0, watchOS 7.0, *) {
                                                     Logger.versionable.error("Couldn't save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                                 } else {
-                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@",
+                                                           log: .versionable, type: .error,
+                                                           error.localizedDescription, self.description)
                                                 }
                                             }
                                         }
@@ -242,35 +256,38 @@ extension PCKVersionable {
                                         if #available(iOS 14.0, watchOS 7.0, *) {
                                             Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                         } else {
-                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@",
+                                                   log: .versionable, type: .error,
+                                                   error.localizedDescription, self.description)
                                         }
                                     }
                                 }
                             }
                         }
-                        
+
                         if modifiedObject.nextVersion != nil {
-                            if modifiedObject.nextVersion!.previousVersion == nil{
-                                modifiedObject.nextVersion!.find(modifiedObject.nextVersion!.uuid) {
-                                    results in
-                                    
+                            if modifiedObject.nextVersion!.previousVersion == nil {
+                                modifiedObject.nextVersion!.find(modifiedObject.nextVersion!.uuid) { results in
+
                                     switch results {
-                                    
+
                                     case .success(let versionedObjectsFound):
                                         guard var nextObjectFound = versionedObjectsFound.first else {
                                             return
                                         }
                                         nextObjectFound.previousVersion = modifiedObject
-                                        nextObjectFound.save(callbackQueue: .main){ results in
+                                        nextObjectFound.save(callbackQueue: .main) { results in
                                             switch results {
-                                                
-                                            case .success(_):
+
+                                            case .success:
                                                 self.fixVersionLinkedList(nextObjectFound, backwards: true)
                                             case .failure(let error):
                                                 if #available(iOS 14.0, watchOS 7.0, *) {
                                                     Logger.versionable.error("Couldn't save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                                 } else {
-                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@",
+                                                           log: .versionable, type: .error,
+                                                           error.localizedDescription, self.description)
                                                 }
                                             }
                                         }
@@ -278,7 +295,9 @@ extension PCKVersionable {
                                         if #available(iOS 14.0, watchOS 7.0, *) {
                                             Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                         } else {
-                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@",
+                                                   log: .versionable, type: .error,
+                                                   error.localizedDescription, self.description)
                                         }
                                     }
                                 }
@@ -286,14 +305,16 @@ extension PCKVersionable {
                         }
                     }
                 }
-                
+
                 completion(.success(savedObject))
 
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.versionable.error("\(versionedObject.className, privacy: .private).save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                 } else {
-                    os_log("%{private}@.save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, versionedObject.className, error.localizedDescription, versionedObject.description)
+                    os_log("%{private}@.save(), %{private}@. Object: %{private}@",
+                           log: .versionable, type: .error, versionedObject.className,
+                           error.localizedDescription, versionedObject.description)
                 }
                 completion(.failure(error))
             }
@@ -305,27 +326,27 @@ extension PCKVersionable {
 extension PCKVersionable {
     private static func queryVersion(for date: Date, queryToAndWith: Query<Self>)-> Query<Self> {
         let interval = createCurrentDateInterval(for: date)
-    
+
         let query = queryToAndWith
             .where(doesNotExist(key: VersionableKey.deletedDate)) //Only consider non deleted keys
             .where(VersionableKey.effectiveDate < interval.end)
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         return query
     }
-    
+
     private static func queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for date: Date)-> Query<Self> {
-        
+
         let query = Self.query(doesNotExist(key: VersionableKey.next))
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         let interval = createCurrentDateInterval(for: date)
         let greaterEqualEffectiveDate = self.query(VersionableKey.effectiveDate >= interval.end)
-        return Self.query(or(queries: [query,greaterEqualEffectiveDate]))
+        return Self.query(or(queries: [query, greaterEqualEffectiveDate]))
     }
-    
+
     func find(for date: Date) throws -> [Self] {
         try Self.query(for: date).find()
     }
-    
+
     /**
      Querying Versioned objects the same way queries are done in CareKit.
      - Parameters:
@@ -335,7 +356,8 @@ extension PCKVersionable {
     */
     //This query doesn't filter nextVersion effectiveDate >= interval.end
     public static func query(for date: Date) -> Query<Self> {
-        let query = queryVersion(for: date, queryToAndWith: queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for: date))
+        let query = queryVersion(for: date,
+                                 queryToAndWith: queryWhereNoNextVersionOrNextVersionGreaterThanEqualToDate(for: date))
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         return query
     }
@@ -347,12 +369,12 @@ extension PCKVersionable {
         - completion: The block to execute.
      It should have the following argument signature: `(Result<[Self],ParseError>)`.
     */
-    public func find(for date: Date, completion: @escaping(Result<[Self],ParseError>) -> Void) {
+    public func find(for date: Date, completion: @escaping(Result<[Self], ParseError>) -> Void) {
         let query = Self.query(for: date)
             .include([VersionableKey.next, VersionableKey.previous, ObjectableKey.notes])
         query.find(callbackQueue: .main) { results in
             switch results {
-            
+
             case .success(let entities):
                 completion(.success(entities))
             case .failure(let error):
@@ -364,7 +386,7 @@ extension PCKVersionable {
 
 //Encodable
 extension PCKVersionable {
-    
+
     /**
      Encodes the PCKVersionable properties of the object
      - Parameters:
@@ -372,11 +394,11 @@ extension PCKVersionable {
     */
     public func encodeVersionable(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: PCKCodingKeys.self)
-        
+
         if encodingForParse {
             try container.encodeIfPresent(nextVersion, forKey: .nextVersion)
             try container.encodeIfPresent(previousVersion, forKey: .previousVersion)
-            
+
         }
         try container.encodeIfPresent(deletedDate, forKey: .deletedDate)
         try container.encodeIfPresent(previousVersionUUID, forKey: .previousVersionUUID)
@@ -391,4 +413,4 @@ extension PCKVersionable {
     public var description: String {
         "className=\(className) uuid=\(String(describing: uuid)) id=\(id) createdDate=\(String(describing: createdDate)) updatedDate=\(String(describing: updatedDate)) schemaVersion=\(String(describing: schemaVersion))  timezone=\(String(describing: timezone)) userInfo=\(String(describing: userInfo)) groupIdentifier=\(String(describing: groupIdentifier)) tags=\(String(describing: tags)) source=\(String(describing: source)) asset=\(String(describing: asset)) remoteID=\(String(describing: remoteID)) notes=\(String(describing: notes)) previousVersionUUID=\(String(describing: previousVersionUUID)) previousVersion=\(String(describing: previousVersion)) nextVersionUUID=\(String(describing: nextVersionUUID)) nextVersion=\(String(describing: nextVersion)) effectiveDate=\(String(describing: effectiveDate)) deletedDate=\(String(describing: deletedDate)) objectId=\(String(describing: objectId)) createdAt=\(String(describing: createdAt)) updatedAt=\(String(describing: updatedAt)) logicalClock=\(String(describing: logicalClock)) encodingForParse=\(encodingForParse) ACL=\(String(describing: ACL))"
     }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -114,7 +114,7 @@ extension PCKVersionable {
                                         case .success(_):
                                             self.fixVersionLinkedList(previousFound, backwards: backwards)
                                         case .failure(let error):
-                                            if #available(iOS 14.0, *) {
+                                            if #available(iOS 14.0, watchOS 7.0, *) {
                                                 Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
                                             } else {
                                                 os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
@@ -125,7 +125,7 @@ extension PCKVersionable {
                                     self.fixVersionLinkedList(previousFound, backwards: backwards)
                                 }
                             case .failure(let error):
-                                if #available(iOS 14.0, *) {
+                                if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
                                 } else {
                                     os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
@@ -161,7 +161,7 @@ extension PCKVersionable {
                                         case .success(_):
                                             self.fixVersionLinkedList(nextFound, backwards: backwards)
                                         case .failure(let error):
-                                            if #available(iOS 14.0, *) {
+                                            if #available(iOS 14.0, watchOS 7.0, *) {
                                                 Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
                                             } else {
                                                 os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
@@ -172,7 +172,7 @@ extension PCKVersionable {
                                     self.fixVersionLinkedList(nextFound, backwards: backwards)
                                 }
                             case .failure(let error):
-                                if #available(iOS 14.0, *) {
+                                if #available(iOS 14.0, watchOS 7.0, *) {
                                     Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
                                 } else {
                                     os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
@@ -201,7 +201,7 @@ extension PCKVersionable {
             switch results {
             
             case .success(let savedObject):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.versionable.debug("Successfully added to cloud: \(savedObject, privacy: .private)")
                 } else {
                     os_log("Successfully added to cloud: %{private}@", log: .versionable, type: .debug, savedObject.description)
@@ -232,7 +232,7 @@ extension PCKVersionable {
                                             case .success(_):
                                                 self.fixVersionLinkedList(previousObjectFound, backwards: true)
                                             case .failure(let error):
-                                                if #available(iOS 14.0, *) {
+                                                if #available(iOS 14.0, watchOS 7.0, *) {
                                                     Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
                                                 } else {
                                                     os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
@@ -240,7 +240,7 @@ extension PCKVersionable {
                                             }
                                         }
                                     case .failure(let error):
-                                        if #available(iOS 14.0, *) {
+                                        if #available(iOS 14.0, watchOS 7.0, *) {
                                             Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
                                         } else {
                                             os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
@@ -268,7 +268,7 @@ extension PCKVersionable {
                                             case .success(_):
                                                 self.fixVersionLinkedList(nextObjectFound, backwards: true)
                                             case .failure(let error):
-                                                if #available(iOS 14.0, *) {
+                                                if #available(iOS 14.0, watchOS 7.0, *) {
                                                     Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
                                                 } else {
                                                     os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
@@ -276,7 +276,7 @@ extension PCKVersionable {
                                             }
                                         }
                                     case .failure(let error):
-                                        if #available(iOS 14.0, *) {
+                                        if #available(iOS 14.0, watchOS 7.0, *) {
                                             Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
                                         } else {
                                             os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
@@ -291,7 +291,7 @@ extension PCKVersionable {
                 completion(.success(savedObject))
 
             case .failure(let error):
-                if #available(iOS 14.0, *) {
+                if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.versionable.error("\(versionedObject.className).save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
                 } else {
                     os_log("%{public}@.save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, versionedObject.className, error.localizedDescription, versionedObject.description)

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -30,7 +30,6 @@ internal protocol PCKVersionable: PCKObjectable, PCKSynchronizable {
     /// The date on which this object was marked deleted. Note that objects are never actually deleted,
     /// but rather they are marked deleted and will no longer be returned from queries.
     var deletedDate: Date? {get set}
-    
 }
 
 extension PCKVersionable {
@@ -384,5 +383,12 @@ extension PCKVersionable {
         try container.encodeIfPresent(nextVersionUUID, forKey: .nextVersionUUID)
         try container.encodeIfPresent(effectiveDate, forKey: .effectiveDate)
         try encodeObjectable(to: encoder)
+    }
+}
+
+//CustomStringConvertible
+extension PCKVersionable {
+    public var description: String {
+        "className=\(className) uuid=\(String(describing: uuid)) id=\(id) createdDate=\(String(describing: createdDate)) updatedDate=\(String(describing: updatedDate)) schemaVersion=\(String(describing: schemaVersion))  timezone=\(String(describing: timezone)) userInfo=\(String(describing: userInfo)) groupIdentifier=\(String(describing: groupIdentifier)) tags=\(String(describing: tags)) source=\(String(describing: source)) asset=\(String(describing: asset)) remoteID=\(String(describing: remoteID)) notes=\(String(describing: notes)) previousVersionUUID=\(String(describing: previousVersionUUID)) previousVersion=\(String(describing: previousVersion)) nextVersionUUID=\(String(describing: nextVersionUUID)) nextVersion=\(String(describing: nextVersion)) effectiveDate=\(String(describing: effectiveDate)) deletedDate=\(String(describing: deletedDate)) objectId=\(String(describing: objectId)) createdAt=\(String(describing: createdAt)) updatedAt=\(String(describing: updatedAt)) logicalClock=\(String(describing: logicalClock)) encodingForParse=\(encodingForParse) ACL=\(String(describing: ACL))"
     }
 }

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -115,9 +115,9 @@ extension PCKVersionable {
                                             self.fixVersionLinkedList(previousFound, backwards: backwards)
                                         case .failure(let error):
                                             if #available(iOS 14.0, watchOS 7.0, *) {
-                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                             } else {
-                                                os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                                os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
                                             }
                                         }
                                     }
@@ -126,9 +126,9 @@ extension PCKVersionable {
                                 }
                             case .failure(let error):
                                 if #available(iOS 14.0, watchOS 7.0, *) {
-                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                 } else {
-                                    os_log("Couldn't save in fixVersionLinkedList(). Error: %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                    os_log("Couldn't save in fixVersionLinkedList(). Error: %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
                                 }
                             }
                         }
@@ -162,9 +162,9 @@ extension PCKVersionable {
                                             self.fixVersionLinkedList(nextFound, backwards: backwards)
                                         case .failure(let error):
                                             if #available(iOS 14.0, watchOS 7.0, *) {
-                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                                Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                             } else {
-                                                os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                                os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
                                             }
                                         }
                                     }
@@ -173,9 +173,9 @@ extension PCKVersionable {
                                 }
                             case .failure(let error):
                                 if #available(iOS 14.0, watchOS 7.0, *) {
-                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription). Object: \(versionFixed, privacy: .private)")
+                                    Logger.versionable.error("Couldn't save in fixVersionLinkedList(),  \(error.localizedDescription, privacy: .private). Object: \(versionFixed, privacy: .private)")
                                 } else {
-                                    os_log("Couldn't save in fixVersionLinkedList(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
+                                    os_log("Couldn't save in fixVersionLinkedList(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, versionFixed.description)
                                 }
                             }
                         }
@@ -233,17 +233,17 @@ extension PCKVersionable {
                                                 self.fixVersionLinkedList(previousObjectFound, backwards: true)
                                             case .failure(let error):
                                                 if #available(iOS 14.0, watchOS 7.0, *) {
-                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                                 } else {
-                                                    os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
                                                 }
                                             }
                                         }
                                     case .failure(let error):
                                         if #available(iOS 14.0, watchOS 7.0, *) {
-                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                         } else {
-                                            os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
                                         }
                                     }
                                 }
@@ -269,17 +269,17 @@ extension PCKVersionable {
                                                 self.fixVersionLinkedList(nextObjectFound, backwards: true)
                                             case .failure(let error):
                                                 if #available(iOS 14.0, watchOS 7.0, *) {
-                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                                    Logger.versionable.error("Couldn't save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                                 } else {
-                                                    os_log("Couldn't save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                                    os_log("Couldn't save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
                                                 }
                                             }
                                         }
                                     case .failure(let error):
                                         if #available(iOS 14.0, watchOS 7.0, *) {
-                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                                            Logger.versionable.error("Couldn't find object in save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                                         } else {
-                                            os_log("Couldn't find object in save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
+                                            os_log("Couldn't find object in save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, error.localizedDescription, self.description)
                                         }
                                     }
                                 }
@@ -292,9 +292,9 @@ extension PCKVersionable {
 
             case .failure(let error):
                 if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.versionable.error("\(versionedObject.className).save(), \(error.localizedDescription). Object: \(self, privacy: .private)")
+                    Logger.versionable.error("\(versionedObject.className, privacy: .private).save(), \(error.localizedDescription, privacy: .private). Object: \(self, privacy: .private)")
                 } else {
-                    os_log("%{public}@.save(), %{public}@. Object: %{private}@", log: .versionable, type: .error, versionedObject.className, error.localizedDescription, versionedObject.description)
+                    os_log("%{private}@.save(), %{private}@. Object: %{private}@", log: .versionable, type: .error, versionedObject.className, error.localizedDescription, versionedObject.description)
                 }
                 completion(.failure(error))
             }

--- a/TestHost/AppDelegate.swift
+++ b/TestHost/AppDelegate.swift
@@ -12,27 +12,21 @@ import ParseCareKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 
 }
-

--- a/TestHost/SceneDelegate.swift
+++ b/TestHost/SceneDelegate.swift
@@ -13,11 +13,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
 
         // Create the SwiftUI view that provides the window contents.
         let contentView = ContentView()
@@ -31,12 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
+    func sceneDidDisconnect(_ scene: UIScene) {}
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
@@ -59,6 +51,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
 }
-

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -563,6 +563,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.content, "world")
         
         //Encode to cloud format
+        parse.values?.first?.objectId = "helloOutcomeValue" //Needs objectId to be ParseObject
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Outcome.self, from: cloudEncoded)

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -70,11 +70,12 @@ func userLoginToRealServer() {
     }
 }
 
+// swiftlint:disable:next type_body_length
 class ParseCareKitTests: XCTestCase {
 
     private var parse: ParseRemoteSynchronizationManager!
     private var store: OCKStore!
-    
+
     override func setUpWithError() throws {
         guard let url = URL(string: "http://localhost:1337/1") else {
                     XCTFail("Should create valid URL")
@@ -87,13 +88,15 @@ class ParseCareKitTests: XCTestCase {
         userLogin()
         //userLoginToRealServer()
         do {
-        parse = try ParseRemoteSynchronizationManager(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false)
+        parse = try ParseRemoteSynchronizationManager(uuid:
+                                                        // swiftlint:disable:next line_length
+                                                        UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false)
         } catch {
             print(error.localizedDescription)
         }
         store = OCKStore(name: "SampleAppStore", type: .onDisk, remote: parse)
         parse?.parseRemoteDelegate = self
-        
+
     }
 
     override func tearDownWithError() throws {
@@ -102,7 +105,8 @@ class ParseCareKitTests: XCTestCase {
         try ParseStorage.shared.deleteAll()
         try store.delete()
     }
-    
+
+    // swiftlint:disable:next function_body_length
     func testNote() throws {
         var careKit = OCKNote(author: "myId", title: "hello", content: "world")
 
@@ -119,7 +123,7 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKit]
-        
+
         //Test CareKit -> Parse
         let parse = try Note.copyCareKit(careKit)
 
@@ -127,7 +131,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.content, careKit.content)
         XCTAssertEqual(parse.title, careKit.title)
         XCTAssertEqual(parse.author, careKit.author)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "Note")
         XCTAssertEqual(parse.uuid, careKit.uuid)
@@ -145,15 +149,15 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
-        
+
         //Special
         XCTAssertEqual(parse2.content, careKit.content)
         XCTAssertEqual(parse2.title, careKit.title)
         XCTAssertEqual(parse2.author, careKit.author)
-        
+
         //Objectable
         XCTAssertEqual(parse2.uuid, careKit.uuid)
         XCTAssertNotNil(parse2.createdDate)
@@ -170,12 +174,12 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Encode to cloud format
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.jsonEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Note.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -198,6 +202,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.author, cloudDecoded.author)
     }
 
+    // swiftlint:disable:next function_body_length
     func testPatient() throws {
         var careKit = OCKPatient(id: "myId", givenName: "hello", familyName: "world")
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
@@ -220,12 +225,12 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
-        
+
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
         careKit.effectiveDate = Date().addingTimeInterval(-199)
-        
+
         //Test CareKit -> Parse
         let parse = try Patient.copyCareKit(careKit)
 
@@ -234,7 +239,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.sex, careKit.sex)
         XCTAssertNotNil(parse.birthday)
         XCTAssertEqual(parse.allergies, careKit.allergies)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "Patient")
         XCTAssertEqual(parse.entityId, careKit.id)
@@ -254,12 +259,12 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
 
@@ -268,7 +273,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.sex, careKit.sex)
         XCTAssertNotNil(parse2.birthday)
         XCTAssertEqual(parse2.allergies, careKit.allergies)
-        
+
         //Objectable
         XCTAssertEqual(parse2.id, careKit.id)
         XCTAssertEqual(parse2.uuid, careKit.uuid)
@@ -287,17 +292,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse2.effectiveDate)
         XCTAssertEqual(parse2.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Encode to cloud format
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Patient.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -319,7 +324,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.sex, cloudDecoded.sex)
         XCTAssertNotNil(cloudDecoded.birthday)
         XCTAssertEqual(parse.allergies, cloudDecoded.allergies)
-        
+
         //Versionable
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, cloudDecoded.previousVersionUUID)
@@ -328,6 +333,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersion, cloudDecoded.nextVersion)
     }
 
+    // swiftlint:disable:next function_body_length
     func testOutcomeValue() throws {
         var careKit = OCKOutcomeValue(10)
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
@@ -335,7 +341,7 @@ class ParseCareKitTests: XCTestCase {
         careKit.index = 0
         //careKit.kind = "whale"
         careKit.units = "m/s"
-        
+
         //Objectable
         careKit.uuid = UUID()
         careKit.createdDate = Date().addingTimeInterval(-200)
@@ -349,7 +355,7 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
-        
+
         //Test CareKit -> Parse
         let parse = try OutcomeValue.copyCareKit(careKit)
 
@@ -363,7 +369,7 @@ class ParseCareKitTests: XCTestCase {
         } else {
             XCTFail("Should have casted")
         }
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "OutcomeValue")
         XCTAssertEqual(parse.uuid, careKit.uuid)
@@ -381,7 +387,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
         //Special
@@ -394,7 +400,7 @@ class ParseCareKitTests: XCTestCase {
         } else {
             XCTFail("Should have casted")
         }
-        
+
         //Objectable
         XCTAssertEqual(parse2.uuid, careKit.uuid)
         XCTAssertNotNil(parse2.createdDate)
@@ -410,7 +416,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Test Parse -> ParseServer
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let encoded = try parse.getJSONEncoder().encode(parse)
@@ -420,7 +426,7 @@ class ParseCareKitTests: XCTestCase {
         } else {
             XCTFail("Should have decoded as a dictionary and had the necessary value")
         }
-        
+
         //Test Parse -> ParseServer
         let parse3 = try parse.getDecoder().decode(OutcomeValue.self, from: encoded)
         //Special
@@ -433,7 +439,7 @@ class ParseCareKitTests: XCTestCase {
         } else {
             XCTFail("Should have casted")
         }
-        
+
         //Objectable
         XCTAssertEqual(parse2.uuid, parse3.uuid)
         XCTAssertEqual(parse2.createdDate, parse3.createdDate)
@@ -449,11 +455,11 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse3.notes?.first?.author, "myId")
         XCTAssertEqual(parse3.notes?.first?.title, "hello")
         XCTAssertEqual(parse3.notes?.first?.content, "world")
-        
+
         //Encode to cloud format
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(OutcomeValue.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -477,10 +483,11 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.value.debugDescription, cloudDecoded.value.debugDescription)
     }
 
+    // swiftlint:disable:next function_body_length
     func testOutcome() throws {
         var careKit = OCKOutcome(taskUUID: UUID(), taskOccurrenceIndex: 0, values: [.init(10)])
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
-        
+
         //Objectable
         careKit.uuid = UUID()
         careKit.createdDate = Date().addingTimeInterval(-200)
@@ -495,8 +502,7 @@ class ParseCareKitTests: XCTestCase {
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
         careKit.timezone = .current
-        
-    
+
         //Test CareKit -> Parse
         let parse = try Outcome.copyCareKit(careKit)
 
@@ -511,7 +517,7 @@ class ParseCareKitTests: XCTestCase {
             return
         }
         XCTAssertEqual(value, careKitValue)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "Outcome")
         XCTAssertEqual(parse.uuid, careKit.uuid)
@@ -530,10 +536,10 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
-        
+
         //Special
         XCTAssertEqual(parse2.taskUUID, careKit.taskUUID)
         XCTAssertEqual(parse2.taskOccurrenceIndex, careKit.taskOccurrenceIndex)
@@ -544,7 +550,7 @@ class ParseCareKitTests: XCTestCase {
         } else {
             XCTFail("Should have casted")
         }
-        
+
         //Objectable
         XCTAssertEqual(parse2.uuid, careKit.uuid)
         XCTAssertNotNil(parse2.createdDate)
@@ -561,13 +567,13 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Encode to cloud format
         parse.values?.first?.objectId = "helloOutcomeValue" //Needs objectId to be ParseObject
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Outcome.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -589,68 +595,20 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.taskOccurrenceIndex, cloudDecoded.taskOccurrenceIndex)
         XCTAssertEqual(parse.values, cloudDecoded.values)
     }
-/*
-    func testScheduleElement() throws {
-        var careKit = OCKScheduleElement(start: Date(), end: Date().addingTimeInterval(3000), interval: .init(day: 1))
 
-        //Objectable
-        careKit.targetValues = [.init(10)]
-        careKit.text = "we"
-        careKit.duration = .allDay
-        
-        do {
-            //Test CareKit -> Parse
-            let parse = try ScheduleElement.copyCareKit(careKit)
-
-            //Special
-            XCTAssertEqual(parse.text, careKit.text)
-            XCTAssertEqual(parse.duration, careKit.duration)
-            XCTAssertEqual(parse.start, careKit.start)
-            XCTAssertEqual(parse.interval, careKit.interval)
-            XCTAssertEqual(parse.end, careKit.end)
-            XCTAssertEqual(parse.targetValues?.count, 1)
-            XCTAssertEqual(parse.targetValues?.count, 1)
-            if let value = parse.targetValues?.first?.value?.value as? Int,
-                let careKitValue = careKit.targetValues.first?.value as? Int {
-                XCTAssertEqual(value, careKitValue)
-            } else {
-                XCTFail("Should have casted")
-            }
-            
-            //Objectable
-            XCTAssertEqual(parse.className, "ScheduleElement")
-            
-            //Test Parse -> CareKit
-            let parse2 = try parse.convertToCareKit()
-            
-            XCTAssertEqual(parse2.text, careKit.text)
-            XCTAssertEqual(parse2.duration, careKit.duration)
-            XCTAssertEqual(parse2.start, careKit.start)
-            XCTAssertEqual(parse2.interval, careKit.interval)
-            XCTAssertEqual(parse2.end, careKit.end)
-            XCTAssertEqual(parse2.targetValues.count, 1)
-            if let value2 = parse2.targetValues.first?.value as? Int,
-               let careKitValue = careKit.targetValues.first?.value as? Int {
-                XCTAssertEqual(value2, careKitValue)
-            } else {
-                XCTFail("Should have casted")
-            }
-            
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }*/
-
+    // swiftlint:disable:next function_body_length
     func testTask() throws {
-        let careKitSchedule = OCKScheduleElement(start: Date(), end: Date().addingTimeInterval(3000), interval: .init(day: 1))
-        var careKit = OCKTask(id: "myId", title: "hello", carePlanUUID: UUID(), schedule: .init(composing: [careKitSchedule]))
+        let careKitSchedule = OCKScheduleElement(start: Date(),
+                                                 end: Date().addingTimeInterval(3000), interval: .init(day: 1))
+        var careKit = OCKTask(id: "myId", title: "hello", carePlanUUID: UUID(),
+                              schedule: .init(composing: [careKitSchedule]))
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
 
         //Special
         careKit.impactsAdherence = true
         careKit.instructions = "sneezing"
         careKit.carePlanUUID = UUID()
-        
+
         //Objectable
         careKit.uuid = UUID()
         careKit.createdDate = Date().addingTimeInterval(-200)
@@ -665,12 +623,12 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
-        
+
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
         careKit.effectiveDate = Date().addingTimeInterval(-199)
-        
+
         //Test CareKit -> Parse
         let parse = try Task.copyCareKit(careKit)
 
@@ -679,7 +637,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.title, careKit.title)
         XCTAssertEqual(parse.carePlanUUID, careKit.carePlanUUID)
         //XCTAssertEqual(parse.allergies, careKit.allergies)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "Task")
         XCTAssertEqual(parse.entityId, careKit.id)
@@ -699,12 +657,12 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
 
@@ -712,7 +670,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.impactsAdherence, careKit.impactsAdherence)
         XCTAssertEqual(parse2.title, careKit.title)
         XCTAssertEqual(parse2.carePlanUUID, careKit.carePlanUUID)
-        
+
         //Objectable
         XCTAssertEqual(parse2.id, careKit.id)
         XCTAssertEqual(parse2.uuid, careKit.uuid)
@@ -731,17 +689,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse2.effectiveDate)
         XCTAssertEqual(parse2.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Encode to cloud format
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Task.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -762,7 +720,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.impactsAdherence, cloudDecoded.impactsAdherence)
         XCTAssertEqual(parse.title, cloudDecoded.title)
         XCTAssertEqual(parse.carePlanUUID, cloudDecoded.carePlanUUID)
-        
+
         //Versionable
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, cloudDecoded.previousVersionUUID)
@@ -771,6 +729,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersion, cloudDecoded.nextVersion)
     }
 
+    // swiftlint:disable:next function_body_length
     func testCarePlan() throws {
         var careKit = OCKCarePlan(id: "myId", title: "hello", patientUUID: UUID())
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
@@ -789,19 +748,19 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
-        
+
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
         careKit.effectiveDate = Date().addingTimeInterval(-199)
-        
+
         //Test CareKit -> Parse
         let parse = try CarePlan.copyCareKit(careKit)
 
         //Special
         XCTAssertEqual(parse.title, careKit.title)
         XCTAssertEqual(parse.patientUUID, careKit.patientUUID)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "CarePlan")
         XCTAssertEqual(parse.entityId, careKit.id)
@@ -821,19 +780,19 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
 
         //Special
         XCTAssertEqual(parse2.title, careKit.title)
         XCTAssertEqual(parse2.patientUUID, careKit.patientUUID)
-        
+
         //Objectable
         XCTAssertEqual(parse2.id, careKit.id)
         XCTAssertEqual(parse2.uuid, careKit.uuid)
@@ -852,17 +811,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse2.effectiveDate)
         XCTAssertEqual(parse2.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Encode to cloud format
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(CarePlan.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -882,7 +841,7 @@ class ParseCareKitTests: XCTestCase {
         //Special
         XCTAssertEqual(parse.title, cloudDecoded.title)
         XCTAssertEqual(parse.patientUUID, cloudDecoded.patientUUID)
-        
+
         //Versionable
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, cloudDecoded.previousVersionUUID)
@@ -891,6 +850,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersion, cloudDecoded.nextVersion)
     }
 
+    // swiftlint:disable:next function_body_length
     func testContact() throws {
         var careKit = OCKContact(id: "myId", givenName: "hello", familyName: "world", carePlanUUID: UUID())
         let careKitNote = OCKNote(author: "myId", title: "hello", content: "world")
@@ -922,12 +882,12 @@ class ParseCareKitTests: XCTestCase {
         careKit.source = "yo"
         careKit.asset = "pic"
         careKit.notes = [careKitNote]
-        
+
         //Versionable
         careKit.previousVersionUUID = UUID()
         careKit.nextVersionUUID = UUID()
         careKit.effectiveDate = Date().addingTimeInterval(-199)
-        
+
         //Test CareKit -> Parse
         let parse = try Contact.copyCareKit(careKit)
 
@@ -941,7 +901,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.emailAddresses, careKit.emailAddresses)
         XCTAssertEqual(parse.phoneNumbers, careKit.phoneNumbers)
         XCTAssertEqual(parse.otherContactInfo, careKit.otherContactInfo)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, "Contact")
         XCTAssertEqual(parse.entityId, careKit.id)
@@ -961,12 +921,12 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.notes?.first?.author, "myId")
         XCTAssertEqual(parse.notes?.first?.title, "hello")
         XCTAssertEqual(parse.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Test Parse -> CareKit
         let parse2 = try parse.convertToCareKit()
 
@@ -980,7 +940,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.emailAddresses, careKit.emailAddresses)
         XCTAssertEqual(parse2.phoneNumbers, careKit.phoneNumbers)
         XCTAssertEqual(parse2.otherContactInfo, careKit.otherContactInfo)
-        
+
         //Objectable
         XCTAssertEqual(parse2.id, careKit.id)
         XCTAssertEqual(parse2.uuid, careKit.uuid)
@@ -999,17 +959,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse2.notes?.first?.author, "myId")
         XCTAssertEqual(parse2.notes?.first?.title, "hello")
         XCTAssertEqual(parse2.notes?.first?.content, "world")
-        
+
         //Versionable
         XCTAssertNotNil(parse2.effectiveDate)
         XCTAssertEqual(parse2.previousVersionUUID, careKit.previousVersionUUID)
         XCTAssertEqual(parse2.nextVersionUUID, careKit.nextVersionUUID)
-        
+
         //Encode to cloud format
         parse.notes?.first?.objectId = "hello" //Needs objectId to be ParseObject
         let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(Contact.self, from: cloudEncoded)
-        
+
         //Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
@@ -1036,7 +996,7 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.emailAddresses, cloudDecoded.emailAddresses)
         XCTAssertEqual(parse.phoneNumbers, cloudDecoded.phoneNumbers)
         XCTAssertEqual(parse.otherContactInfo, cloudDecoded.otherContactInfo)
-        
+
         //Versionable
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUID, cloudDecoded.previousVersionUUID)
@@ -1081,17 +1041,18 @@ extension ParseCareKitTests: ParseRemoteSynchronizationDelegate {
     func didRequestSynchronization(_ remote: OCKRemoteSynchronizable) {
         print("Implement")
     }
-    
+
     func remote(_ remote: OCKRemoteSynchronizable, didUpdateProgress progress: Double) {
         print("Implement")
     }
-    
-    func successfullyPushedDataToCloud(){
+
+    func successfullyPushedDataToCloud() {
         print("Implement")
     }
-    
-    func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
+
+    func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
+                                        completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
         let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
         completion(conflictPolicy)
     }
-}
+} // swiftlint:disable:this file_length

--- a/Tests/ParseCareKitTests/LoggerTests.swift
+++ b/Tests/ParseCareKitTests/LoggerTests.swift
@@ -1,0 +1,111 @@
+//
+//  LoggerTests.swift
+//  ParseCareKitTests
+//
+//  Created by Corey Baker on 12/13/20.
+//  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ParseCareKit
+import os.log
+
+class LoggerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testCarePlan() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.carePlan.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .carePlan, type: .error)
+        }
+    }
+
+    func testContact() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.contact.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .contact, type: .error)
+        }
+    }
+
+    func testPatient() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.patient.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .patient, type: .error)
+        }
+    }
+
+    func testTask() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.task.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .task, type: .error)
+        }
+    }
+
+    func testOutcome() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.outcome.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .outcome, type: .error)
+        }
+    }
+
+    func testVersionable() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.versionable.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .versionable, type: .error)
+        }
+    }
+
+    func testObjectable() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.objectable.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .objectable, type: .error)
+        }
+    }
+
+    func testPullRevisions() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.pullRevisions.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .pullRevisions, type: .error)
+        }
+    }
+
+    func testPushRevisions() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.pushRevisions.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .pushRevisions, type: .error)
+        }
+    }
+
+    func testClock() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.clock.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .clock, type: .error)
+        }
+    }
+}


### PR DESCRIPTION
- [x] Syncing Notes - The Parse-Swift dependency had a bug preventing arrays of objects being saved properly. Saving OutcomeValues were designed to work with the bug, so some fixes are here to make those save correctly. Fix #74 
- [x] Replace print statements with `Logger` and `os_log`
- [x] Add SwiftLint and CONTRIBUTIONS.md
- [x] Make protocols public 