### PR TITLE
Dependency update. Add LiveQuery

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
           "branch": "main",
-          "revision": "4936c622d55d876ccf43d7a4f4fa6acdf4db6747",
+          "revision": "56796e8c7915b5813a47f54d746219a29685cb81",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": "main",
-          "revision": "ca096b5f5b4c6392cd22c562c3755fbd01e89ffc",
+          "revision": "db6e7bd796ce2f195b31ecf867f1fd17065c8c0b",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": "main",
-          "revision": "e2dde15dc6d9655498521edba6d676d49de71d51",
+          "revision": "ca096b5f5b4c6392cd22c562c3755fbd01e89ffc",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": "main",
-          "revision": "ea76851b880fc1d65bc657318555c9542282f8ad",
+          "revision": "ca096b5f5b4c6392cd22c562c3755fbd01e89ffc",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": "main",
-          "revision": "ca096b5f5b4c6392cd22c562c3755fbd01e89ffc",
+          "revision": "db6e7bd796ce2f195b31ecf867f1fd17065c8c0b",
           "version": null
         }
       }

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
           "branch": "main",
-          "revision": "4936c622d55d876ccf43d7a4f4fa6acdf4db6747",
+          "revision": "56796e8c7915b5813a47f54d746219a29685cb81",
           "version": null
         }
       },

--- a/README.md
+++ b/README.md
@@ -136,15 +136,15 @@ Register as a delegate just in case ParseCareKit needs your application to updat
 ```swift
 extension AppDelegate: OCKRemoteSynchronizationDelegate, ParseRemoteSynchronizationDelegate{
     func didRequestSynchronization(_ remote: OCKRemoteSynchronizable) {
-        print("Implement")
+        print("Implement so ParseCareKit can tell your OCKStore to sync to the cloud")
+        //example
+        store.synchronize { error in
+            print(error?.localizedDescription ?? "Successful sync with remote!")
+        }
     }
     
     func remote(_ remote: OCKRemoteSynchronizable, didUpdateProgress progress: Double) {
-        print("Implement")
-    }
-    
-    func successfullyPushedDataToCloud(){
-        print("Notified when data is succefully pushed to the cloud")
+        print("Completed: \(progress)")
     }
 
     func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription, completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -138,8 +138,7 @@ public final class CarePlan: PCKVersionable {
     }
 
     public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -183,8 +182,7 @@ public final class CarePlan: PCKVersionable {
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid,
+        guard let uuid = self.uuid,
             let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
@@ -331,7 +329,7 @@ public final class CarePlan: PCKVersionable {
         guard let carePlan = carePlanAny as? OCKCarePlan else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
-        let encoded = try ParseCareKitUtility.encoder().encode(carePlan)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(carePlan)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = carePlan.id
         return decoded

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -74,7 +74,7 @@ struct Clock: ParseObject {
     static func fetchFromCloud(uuid: UUID, createNewIfNeeded: Bool,
                                completion:@escaping(Clock?,
                                                     OCKRevisionRecord.KnowledgeVector?,
-                                                    ParseError?) -> Void) -> Query<Clock> {
+                                                    ParseError?) -> Void) {
 
         //Fetch Clock from Cloud
         let query = Clock.query(ClockKey.uuid == uuid)
@@ -98,6 +98,5 @@ struct Clock: ParseObject {
                 }
             }
         }
-        return query
     }
 }

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -72,7 +72,9 @@ struct Clock: ParseObject {
     }
 
     static func fetchFromCloud(uuid: UUID, createNewIfNeeded: Bool,
-                               completion:@escaping(Clock?, OCKRevisionRecord.KnowledgeVector?, ParseError?) -> Void) {
+                               completion:@escaping(Clock?,
+                                                    OCKRevisionRecord.KnowledgeVector?,
+                                                    ParseError?) -> Void) -> Query<Clock> {
 
         //Fetch Clock from Cloud
         let query = Clock.query(ClockKey.uuid == uuid)
@@ -96,5 +98,6 @@ struct Clock: ParseObject {
                 }
             }
         }
+        return query
     }
 }

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -170,8 +170,7 @@ public final class Contact: PCKVersionable {
 
     public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
 
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -215,8 +214,7 @@ public final class Contact: PCKVersionable {
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid,
+        guard let uuid = self.uuid,
             let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
@@ -370,7 +368,7 @@ public final class Contact: PCKVersionable {
         guard let contact = contactAny as? OCKContact else {
             throw ParseCareKitError.cantCastToNeededClassType
         }
-        let encoded = try ParseCareKitUtility.encoder().encode(contact)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(contact)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = contact.id
         return decoded

--- a/Sources/ParseCareKit/Objects/Note.swift
+++ b/Sources/ParseCareKit/Objects/Note.swift
@@ -92,7 +92,7 @@ open class Note: PCKObjectable {
     }
 
     open class func copyCareKit(_ note: OCKNote) throws -> Note {
-        let encoded = try ParseCareKitUtility.encoder().encode(note)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(note)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         return decoded
     }

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -124,8 +124,7 @@ open class Outcome: PCKObjectable, PCKSynchronizable {
 
     public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
 
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -268,8 +267,7 @@ open class Outcome: PCKObjectable, PCKSynchronizable {
 
     public func tombstone(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
 
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -339,7 +337,7 @@ open class Outcome: PCKObjectable, PCKSynchronizable {
             throw ParseCareKitError.cantCastToNeededClassType
         }
 
-        let encoded = try ParseCareKitUtility.encoder().encode(outcome)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(outcome)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = outcome.id
         return decoded

--- a/Sources/ParseCareKit/Objects/OutcomeValue.swift
+++ b/Sources/ParseCareKit/Objects/OutcomeValue.swift
@@ -189,7 +189,7 @@ open class OutcomeValue: PCKObjectable {
     }
 
     public class func copyCareKit(_ outcomeValue: OCKOutcomeValue) throws -> OutcomeValue {
-        let encoded = try ParseCareKitUtility.encoder().encode(outcomeValue)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(outcomeValue)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         return decoded
     }

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -136,8 +136,7 @@ public final class Patient: PCKVersionable {
     }
 
     public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -182,8 +181,7 @@ public final class Patient: PCKVersionable {
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid,
+        guard let uuid = self.uuid,
             let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
@@ -331,7 +329,7 @@ public final class Patient: PCKVersionable {
             throw ParseCareKitError.cantCastToNeededClassType
         }
 
-        let encoded = try ParseCareKitUtility.encoder().encode(patient)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(patient)
         let decoded = try ParseCareKitUtility.decoder().decode(Patient.self, from: encoded)
         decoded.entityId = patient.id
         return decoded

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -148,8 +148,7 @@ public final class Task: PCKVersionable {
     }
 
     public func addToCloud(overwriteRemote: Bool, completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid else {
+        guard let uuid = self.uuid else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
         }
@@ -194,8 +193,7 @@ public final class Task: PCKVersionable {
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        guard PCKUser.current != nil,
-              let uuid = self.uuid,
+        guard let uuid = self.uuid,
             let previousVersionUUID = self.previousVersionUUID else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
             return
@@ -346,7 +344,7 @@ public final class Task: PCKVersionable {
             throw ParseCareKitError.cantCastToNeededClassType
         }
 
-        let encoded = try ParseCareKitUtility.encoder().encode(task)
+        let encoded = try ParseCareKitUtility.jsonEncoder().encode(task)
         let decoded = try ParseCareKitUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
         return decoded

--- a/Sources/ParseCareKit/ParseCareKitUtility.swift
+++ b/Sources/ParseCareKit/ParseCareKitUtility.swift
@@ -33,13 +33,16 @@ public struct ParseCareKitUtility {
 
         guard let parseDictionary = plistConfiguration["ParseClientConfiguration"] as? [String: AnyObject],
             let appID = parseDictionary["ApplicationID"] as? String,
-            let server = parseDictionary["Server"] as? String,
-            let serverURL = URL(string: server),
+            let serverURL = parseDictionary["Server"] as? URL,
             (parseDictionary["EnableLocalDataStore"] as? Bool) != nil else {
                 fatalError("Error in ParseCareKit.setupServer(). Missing keys in \(plistConfiguration)")
         }
 
-        ParseSwift.initialize(applicationId: appID, serverURL: serverURL)
+        if let liveQueryURL = parseDictionary["LiveQueryServer"] as? URL {
+            ParseSwift.initialize(applicationId: appID, serverURL: serverURL, liveQueryServerURL: liveQueryURL)
+        } else {
+            ParseSwift.initialize(applicationId: appID, serverURL: serverURL)
+        }
     }
 
     /// Converts a date to a String.

--- a/Sources/ParseCareKit/ParseCareKitUtility.swift
+++ b/Sources/ParseCareKit/ParseCareKitUtility.swift
@@ -33,12 +33,14 @@ public struct ParseCareKitUtility {
 
         guard let parseDictionary = plistConfiguration["ParseClientConfiguration"] as? [String: AnyObject],
             let appID = parseDictionary["ApplicationID"] as? String,
-            let serverURL = parseDictionary["Server"] as? URL,
+            let server = parseDictionary["Server"] as? String,
+            let serverURL = URL(string: server),
             (parseDictionary["EnableLocalDataStore"] as? Bool) != nil else {
                 fatalError("Error in ParseCareKit.setupServer(). Missing keys in \(plistConfiguration)")
         }
 
-        if let liveQueryURL = parseDictionary["LiveQueryServer"] as? URL {
+        if let liveQuery = parseDictionary["LiveQueryServer"] as? String,
+           let liveQueryURL = URL(string: liveQuery) {
             ParseSwift.initialize(applicationId: appID, serverURL: serverURL, liveQueryServerURL: liveQueryURL)
         } else {
             ParseSwift.initialize(applicationId: appID, serverURL: serverURL)

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -163,7 +163,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
 
         let classNames = PCKStoreClass.patient.orderedArray()
         if classNames.count > 0 {
-            let ratioComplete = Double(concreteClassesAlreadyPulled/(classNames.count - 1))
+            let ratioComplete = Double(concreteClassesAlreadyPulled)/Double(classNames.count)
             self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.pullRevisions.info("pullRevisionsForConcreteClasses progress: \(ratioComplete, privacy: .private)")
@@ -215,7 +215,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             let classNames = customClassesToSynchronize.keys.sorted()
 
             if classNames.count > 0 {
-                let ratioComplete = Double(customClassesAlreadyPulled/(classNames.count - 1))
+                let ratioComplete = Double(customClassesAlreadyPulled)/Double(classNames.count)
                 self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.pullRevisions.info("pullRevisionsForCustomClasses progress: \(ratioComplete, privacy: .private)")
@@ -331,7 +331,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             var revisionsCompletedCount = 0
             deviceRevision.entities.forEach {
                 if deviceRevision.entities.count > 0 {
-                    let ratioComplete = Double(revisionsCompletedCount/(deviceRevision.entities.count - 1))
+                    let ratioComplete = Double(revisionsCompletedCount)/Double(deviceRevision.entities.count)
                     self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger.pullRevisions.info("pushRevisions progress: \(ratioComplete, privacy: .private)")
@@ -577,7 +577,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
     public func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
                                                completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void) {
         if let parseDelegate = parseDelegate {
-            parseRemoteDelegate!.chooseConflictResolutionPolicy(conflict, completion: completion)
+            parseDelegate.chooseConflictResolutionPolicy(conflict, completion: completion)
         } else {
             let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
             completion(conflictPolicy)

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -102,7 +102,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                               completion: @escaping (Error?) -> Void) {
 
         //Fetch Clock from Cloud
-        let clockQuery = Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: false) { (_, potentialCKClock, _) in
+        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: false) { (_, potentialCKClock, _) in
             guard let cloudVector = potentialCKClock else {
                 //No Clock available, need to let CareKit know this is the first sync.
                 let revision = OCKRevisionRecord(entities: [], knowledgeVector: .init())
@@ -122,6 +122,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                                                    completion: completion)
             }
         }
+        let clockQuery = Clock.query(ClockKey.uuid == uuid)
         guard let subscription = clockQuery.subscribe else {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.pullRevisions.error("Couldn't subscribe to clock query.")
@@ -132,7 +133,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             }
             return
         }
-        subscription.handleSubscribe { (_, _) in
+        subscription.handleEvent { (_, _) in
             self.delegate?.didRequestSynchronization(self)
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger
@@ -246,7 +247,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
         }
 
         //Fetch Clock from Cloud
-        _ = Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: true) { (potentialPCKClock, potentialCKClock, error) in
+        Clock.fetchFromCloud(uuid: uuid, createNewIfNeeded: true) { (potentialPCKClock, potentialCKClock, error) in
 
             guard let cloudParseVector = potentialPCKClock,
                 let cloudCareKitVector = potentialCKClock else {

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -162,13 +162,15 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                                          completion: @escaping (Error?) -> Void) {
 
         let classNames = PCKStoreClass.patient.orderedArray()
-        let ratioComplete = Double(concreteClassesAlreadyPulled/(classNames.count - 1))
-        self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
-        if #available(iOS 14.0, watchOS 7.0, *) {
-            Logger.pullRevisions.info("pullRevisionsForConcreteClasses progress: \(ratioComplete, privacy: .private)")
-        } else {
-            os_log("pullRevisionsForConcreteClasses progress: %{private}@.",
-                   log: .pullRevisions, type: .default, ratioComplete)
+        if classNames.count > 0 {
+            let ratioComplete = Double(concreteClassesAlreadyPulled/(classNames.count - 1))
+            self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
+            if #available(iOS 14.0, watchOS 7.0, *) {
+                Logger.pullRevisions.info("pullRevisionsForConcreteClasses progress: \(ratioComplete, privacy: .private)")
+            } else {
+                os_log("pullRevisionsForConcreteClasses progress: %{private}@.",
+                       log: .pullRevisions, type: .default, ratioComplete)
+            }
         }
 
         guard concreteClassesAlreadyPulled < classNames.count,
@@ -328,16 +330,16 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             let cloudVectorClock = cloudCareKitVector.clock(for: self.uuid)
             var revisionsCompletedCount = 0
             deviceRevision.entities.forEach {
-
-                let ratioComplete = Double(revisionsCompletedCount/(deviceRevision.entities.count - 1))
-                self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
-                if #available(iOS 14.0, watchOS 7.0, *) {
-                    Logger.pullRevisions.info("pushRevisions progress: \(ratioComplete, privacy: .private)")
-                } else {
-                    os_log("pushRevisions progress: %{private}@.",
-                           log: .pullRevisions, type: .default, ratioComplete)
+                if deviceRevision.entities.count > 0 {
+                    let ratioComplete = Double(revisionsCompletedCount/(deviceRevision.entities.count - 1))
+                    self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
+                    if #available(iOS 14.0, watchOS 7.0, *) {
+                        Logger.pullRevisions.info("pushRevisions progress: \(ratioComplete, privacy: .private)")
+                    } else {
+                        os_log("pushRevisions progress: %{private}@.",
+                               log: .pullRevisions, type: .default, ratioComplete)
+                    }
                 }
-
                 let entity = $0
                 switch entity {
                 case .patient(let patient):

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -141,7 +141,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                 }
                 self.clockSubscription = subscription
                 self.clockSubscription!.handleEvent { (_, _) in
-                    self.delegate?.didRequestSynchronization(self)
+                    self.parseDelegate?.didRequestSynchronization(self)
                     if #available(iOS 14.0, watchOS 7.0, *) {
                         Logger
                             .pullRevisions

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -122,7 +122,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                                                    completion: completion)
             }
         }
-        if subscribeToServerUpdates {
+        if subscribeToServerUpdates && clockSubscription == nil {
             let clockQuery = Clock.query(ClockKey.uuid == uuid)
             guard let subscription = clockQuery.subscribe else {
                 if #available(iOS 14.0, watchOS 7.0, *) {

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -134,8 +134,7 @@ extension PCKObjectable {
     */
     static public func first(_ uuid: UUID?, relatedObject: Self?=nil, completion: @escaping(Result<Self, Error>) -> Void) {
 
-        guard PCKUser.current != nil,
-            let uuidString = uuid?.uuidString else {
+        guard let uuidString = uuid?.uuidString else {
             completion(.failure(ParseCareKitError.requiredValueCantBeUnwrapped))
                 return
         }
@@ -171,8 +170,7 @@ extension PCKObjectable {
     public func find(_ uuid: UUID?,
                      completion: @escaping(Result<[Self], Error>) -> Void) {
 
-        guard PCKUser.current != nil,
-            let uuidString = uuid?.uuidString else {
+        guard let uuidString = uuid?.uuidString else {
 
             if #available(iOS 14.0, watchOS 7.0, *) {
                 Logger.objectable.error("\(self.className, privacy: .private).find(), \(ParseCareKitError.requiredValueCantBeUnwrapped.localizedDescription, privacy: .private).")

--- a/Sources/ParseCareKit/Protocols/ParseRemoteSynchronizationDelegate.swift
+++ b/Sources/ParseCareKit/Protocols/ParseRemoteSynchronizationDelegate.swift
@@ -16,5 +16,10 @@ import CareKitStore
 public protocol ParseRemoteSynchronizationDelegate: OCKRemoteSynchronizationDelegate {
     func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
                                         completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void)
+    /// Be notified when data has succesfully been pushed to the Cloud.
     func successfullyPushedDataToCloud()
+}
+
+extension ParseRemoteSynchronizationDelegate {
+    func successfullyPushedDataToCloud() { }
 }

--- a/Sources/ParseCareKit/Protocols/ParseRemoteSynchronizationDelegate.swift
+++ b/Sources/ParseCareKit/Protocols/ParseRemoteSynchronizationDelegate.swift
@@ -14,12 +14,7 @@ import CareKitStore
  able to respond to updates and resolve conflicts when needed.
 */
 public protocol ParseRemoteSynchronizationDelegate: OCKRemoteSynchronizationDelegate {
+    /// When a conflict occurs, decide if the device or cloud record should be kept.
     func chooseConflictResolutionPolicy(_ conflict: OCKMergeConflictDescription,
                                         completion: @escaping (OCKMergeConflictResolutionPolicy) -> Void)
-    /// Be notified when data has succesfully been pushed to the Cloud.
-    func successfullyPushedDataToCloud()
-}
-
-extension ParseRemoteSynchronizationDelegate {
-    func successfullyPushedDataToCloud() { }
 }

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -44,7 +44,7 @@ func userLogin() {
 
     MockURLProtocol.mockRequests { _ in
         do {
-            let encoded = try loginResponse.getEncoder(skipKeys: false).encode(loginResponse)
+            let encoded = try ParseCoding.jsonEncoder().encode(loginResponse)
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         } catch {
             return nil
@@ -85,7 +85,7 @@ class ParseCareKitTests: XCTestCase {
                                       clientKey: "clientKey",
                                       masterKey: "masterKey",
                                       serverURL: url)
-        userLogin()
+        //userLogin()
         //userLoginToRealServer()
         do {
         parse = try ParseRemoteSynchronizationManager(uuid:

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -90,7 +90,7 @@ class ParseCareKitTests: XCTestCase {
         do {
         parse = try ParseRemoteSynchronizationManager(uuid:
                                                         // swiftlint:disable:next line_length
-                                                        UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false)
+                                                        UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false, subscribeToServerUpdates: false)
         } catch {
             print(error.localizedDescription)
         }


### PR DESCRIPTION
- [x] Add LiveQuery support for automatic updates across user devices. Each user device can automatically subscribe to receive updates across devices using LiveQuery. Be sure to use the latest [parse-hipaa](https://github.com/netreconlab/parse-hipaa) to enable server-side.
- [x] Improve `ParseRemoteSynchronizationDelegate`. Provides synchronization progress updates.
- [x] Update to latest Parse-Swift.
- [x] Update to latest CareKit.