### PR TITLE
Refactor ParseRemoteSynchronizationManager -> ParseRemote

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/gavirawson-apple/CareKit",
+        "repositoryURL": "https://github.com/carekit-apple/CareKit",
         "state": {
           "branch": null,
-          "revision": "833fe88e7e96884a52ed173ed4a2a7875a49974d",
+          "revision": "0c0cbe3abd2f0a1fd788a857f137d1726f0940f2",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "453ebdbcddf30cf3baad6bcf79fbc1fc0ba07fe2",
-          "version": "1.2.2"
+          "revision": "a233682449b6053810c5af523d02788c6d348660",
+          "version": "1.2.4"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
+        "repositoryURL": "https://github.com/gavirawson-apple/CareKit",
         "state": {
           "branch": null,
-          "revision": "6e7efbe17c6a4112c54abb7bf9c6387a0d2b132f",
+          "revision": "833fe88e7e96884a52ed173ed4a2a7875a49974d",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "CareKit", url: "https://github.com/gavirawson-apple/CareKit",
-                 .revision("833fe88e7e96884a52ed173ed4a2a7875a49974d")),
-        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.2.2")
+        .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit",
+                 .revision("0c0cbe3abd2f0a1fd788a857f137d1726f0940f2")),
+        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.2.4")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit.git",
-                 .revision("6e7efbe17c6a4112c54abb7bf9c6387a0d2b132f")),
+        .package(name: "CareKit", url: "https://github.com/gavirawson-apple/CareKit",
+                 .revision("833fe88e7e96884a52ed173ed4a2a7875a49974d")),
         .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.2.2")
     ],
     targets: [

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		709D18072586903C0002E772 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D18062586903C0002E772 /* LoggerTests.swift */; };
 		709D1818258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
 		709D1819258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
+		70AB7046260BF584005A91C6 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70AB7045260BF584005A91C6 /* CareKitStore */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70D5A29425E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
@@ -164,6 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70AB7046260BF584005A91C6 /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -419,6 +421,7 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
+				70AB7045260BF584005A91C6 /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -1062,6 +1065,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
 			productName = ParseSwift;
+		};
+		70AB7045260BF584005A91C6 /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -8,8 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
-		705B5A1325E415F800FA65EF /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 705B5A1225E415F800FA65EF /* CareKitStore */; };
-		705B5A1725E4160B00FA65EF /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 705B5A1625E4160B00FA65EF /* CareKitStore */; };
+		70097C93260BF2B800361B45 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70097C92260BF2B800361B45 /* CareKitStore */; };
 		705DC9222526A4B80035BBE3 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
@@ -165,7 +164,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				705B5A1725E4160B00FA65EF /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,7 +172,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				705B5A1325E415F800FA65EF /* CareKitStore in Frameworks */,
+				70097C93260BF2B800361B45 /* CareKitStore in Frameworks */,
 				7075542D255D899E00172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -421,7 +419,6 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
-				705B5A1625E4160B00FA65EF /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -445,7 +442,7 @@
 			name = ParseCareKit;
 			packageProductDependencies = (
 				7075542C255D899E00172F6B /* ParseSwift */,
-				705B5A1225E415F800FA65EF /* CareKitStore */,
+				70097C92260BF2B800361B45 /* CareKitStore */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -487,7 +484,7 @@
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
 				7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */,
-				705B5A1125E415F800FA65EF /* XCRemoteSwiftPackageReference "CareKit" */,
+				70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1032,12 +1029,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		705B5A1125E415F800FA65EF /* XCRemoteSwiftPackageReference "CareKit" */ = {
+		70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
+			repositoryURL = "https://github.com/gavirawson-apple/CareKit";
 			requirement = {
-				kind = revision;
-				revision = 6e7efbe17c6a4112c54abb7bf9c6387a0d2b132f;
+				branch = main;
+				kind = branch;
 			};
 		};
 		7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
@@ -1051,14 +1048,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		705B5A1225E415F800FA65EF /* CareKitStore */ = {
+		70097C92260BF2B800361B45 /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 705B5A1125E415F800FA65EF /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
-		};
-		705B5A1625E4160B00FA65EF /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 705B5A1125E415F800FA65EF /* XCRemoteSwiftPackageReference "CareKit" */;
+			package = 70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
 		};
 		7075542C255D899E00172F6B /* ParseSwift */ = {

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
-		70097C93260BF2B800361B45 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70097C92260BF2B800361B45 /* CareKitStore */; };
+		7019B3E6260FA209004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B3E5260FA209004E4A3A /* CareKitStore */; };
+		7019B3EA260FA217004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B3E9260FA217004E4A3A /* CareKitStore */; };
 		705DC9222526A4B80035BBE3 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
@@ -30,7 +31,6 @@
 		709D18072586903C0002E772 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D18062586903C0002E772 /* LoggerTests.swift */; };
 		709D1818258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
 		709D1819258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
-		70AB7046260BF584005A91C6 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70AB7045260BF584005A91C6 /* CareKitStore */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70D5A29425E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
@@ -165,7 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70AB7046260BF584005A91C6 /* CareKitStore in Frameworks */,
+				7019B3EA260FA217004E4A3A /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,7 +174,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70097C93260BF2B800361B45 /* CareKitStore in Frameworks */,
+				7019B3E6260FA209004E4A3A /* CareKitStore in Frameworks */,
 				7075542D255D899E00172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -421,7 +421,7 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
-				70AB7045260BF584005A91C6 /* CareKitStore */,
+				7019B3E9260FA217004E4A3A /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -445,7 +445,7 @@
 			name = ParseCareKit;
 			packageProductDependencies = (
 				7075542C255D899E00172F6B /* ParseSwift */,
-				70097C92260BF2B800361B45 /* CareKitStore */,
+				7019B3E5260FA209004E4A3A /* CareKitStore */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -487,7 +487,7 @@
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
 				7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */,
-				70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */,
+				7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1032,12 +1032,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */ = {
+		7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/gavirawson-apple/CareKit";
+			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = 0c0cbe3abd2f0a1fd788a857f137d1726f0940f2;
 			};
 		};
 		7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
@@ -1045,15 +1045,20 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.2;
+				minimumVersion = 1.2.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		70097C92260BF2B800361B45 /* CareKitStore */ = {
+		7019B3E5260FA209004E4A3A /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */;
+			package = 7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
+		};
+		7019B3E9260FA217004E4A3A /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
 		};
 		7075542C255D899E00172F6B /* ParseSwift */ = {
@@ -1065,11 +1070,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
 			productName = ParseSwift;
-		};
-		70AB7045260BF584005A91C6 /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70097C91260BF2B800361B45 /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		709D176B258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
 		709D176C258579090002E772 /* ParseCareKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D176A258579090002E772 /* ParseCareKitError.swift */; };
 		709D18072586903C0002E772 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D18062586903C0002E772 /* LoggerTests.swift */; };
-		709D1818258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
-		709D1819258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */; };
+		709D1818258699840002E772 /* ParseRemoteDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteDelegate.swift */; };
+		709D1819258699840002E772 /* ParseRemoteDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteDelegate.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70D5A29425E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
@@ -42,7 +42,7 @@
 		70F2E186254EFC8000B2EA5C /* Outcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D5FF24561A28001B7AA3 /* Outcome.swift */; };
 		70F2E187254EFC8000B2EA5C /* ParseCareKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */; };
 		70F2E188254EFC8000B2EA5C /* ParseCareKitUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */; };
-		70F2E189254EFC8000B2EA5C /* ParseRemoteSynchronizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */; };
+		70F2E189254EFC8000B2EA5C /* ParseRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemote.swift */; };
 		70F2E18A254EFC8000B2EA5C /* PCKSynchronizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D5287924813AF70022292B /* PCKSynchronizable.swift */; };
 		70F2E18C254EFC8000B2EA5C /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
 		70F2E18D254EFC8000B2EA5C /* Clock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA07222466F0CD00B39452 /* Clock.swift */; };
@@ -57,7 +57,7 @@
 		9119D60B24561B02001B7AA3 /* ParseCareKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */; };
 		9119D60D24561B22001B7AA3 /* ParseCareKitUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */; };
 		9119D69A245689DA001B7AA3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 9119D699245689D9001B7AA3 /* README.md */; };
-		916570D72462DABC008F2997 /* ParseRemoteSynchronizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */; };
+		916570D72462DABC008F2997 /* ParseRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemote.swift */; };
 		918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		91AA07232466F0CD00B39452 /* Clock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA07222466F0CD00B39452 /* Clock.swift */; };
 		91D5287A24813AF70022292B /* PCKSynchronizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D5287924813AF70022292B /* PCKSynchronizable.swift */; };
@@ -121,7 +121,7 @@
 		709D175C258551D20002E772 /* ParseCareKitLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitLog.swift; sourceTree = "<group>"; };
 		709D176A258579090002E772 /* ParseCareKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitError.swift; sourceTree = "<group>"; };
 		709D18062586903C0002E772 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
-		709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemoteSynchronizationDelegate.swift; sourceTree = "<group>"; };
+		709D1817258699840002E772 /* ParseRemoteDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemoteDelegate.swift; sourceTree = "<group>"; };
 		70B326BD251EBE610028B229 /* PCKUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUser.swift; sourceTree = "<group>"; };
 		70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTask.swift; sourceTree = "<group>"; };
 		70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ParseCareKit_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,7 +138,7 @@
 		9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitConstants.swift; sourceTree = "<group>"; };
 		9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitUtility.swift; sourceTree = "<group>"; };
 		9119D699245689D9001B7AA3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemoteSynchronizationManager.swift; sourceTree = "<group>"; };
+		916570D62462DABC008F2997 /* ParseRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemote.swift; sourceTree = "<group>"; };
 		918F07ED247D66C800C3A205 /* PCKObjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKObjectable.swift; sourceTree = "<group>"; };
 		91AA07222466F0CD00B39452 /* Clock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clock.swift; sourceTree = "<group>"; };
 		91D5287924813AF70022292B /* PCKSynchronizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKSynchronizable.swift; sourceTree = "<group>"; };
@@ -315,7 +315,7 @@
 				709D176A258579090002E772 /* ParseCareKitError.swift */,
 				709D175C258551D20002E772 /* ParseCareKitLog.swift */,
 				9119D60C24561B22001B7AA3 /* ParseCareKitUtility.swift */,
-				916570D62462DABC008F2997 /* ParseRemoteSynchronizationManager.swift */,
+				916570D62462DABC008F2997 /* ParseRemote.swift */,
 			);
 			path = ParseCareKit;
 			sourceTree = "<group>";
@@ -340,7 +340,7 @@
 				918F07ED247D66C800C3A205 /* PCKObjectable.swift */,
 				91D5287924813AF70022292B /* PCKSynchronizable.swift */,
 				700775A92522686D00EC0EDA /* PCKVersionable.swift */,
-				709D1817258699840002E772 /* ParseRemoteSynchronizationDelegate.swift */,
+				709D1817258699840002E772 /* ParseRemoteDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -601,7 +601,7 @@
 			files = (
 				709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */,
 				70F2E187254EFC8000B2EA5C /* ParseCareKitConstants.swift in Sources */,
-				70F2E189254EFC8000B2EA5C /* ParseRemoteSynchronizationManager.swift in Sources */,
+				70F2E189254EFC8000B2EA5C /* ParseRemote.swift in Sources */,
 				70F2E183254EFC8000B2EA5C /* Contact.swift in Sources */,
 				70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */,
 				70F2E184254EFC8000B2EA5C /* PCKUser.swift in Sources */,
@@ -614,7 +614,7 @@
 				70F2E188254EFC8000B2EA5C /* ParseCareKitUtility.swift in Sources */,
 				70F2E185254EFC8000B2EA5C /* CarePlan.swift in Sources */,
 				70F2E18A254EFC8000B2EA5C /* PCKSynchronizable.swift in Sources */,
-				709D1819258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */,
+				709D1819258699840002E772 /* ParseRemoteDelegate.swift in Sources */,
 				70F2E18C254EFC8000B2EA5C /* PCKVersionable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -637,8 +637,8 @@
 				91AA07232466F0CD00B39452 /* Clock.swift in Sources */,
 				9119D60424561A28001B7AA3 /* Patient.swift in Sources */,
 				91D5287A24813AF70022292B /* PCKSynchronizable.swift in Sources */,
-				709D1818258699840002E772 /* ParseRemoteSynchronizationDelegate.swift in Sources */,
-				916570D72462DABC008F2997 /* ParseRemoteSynchronizationManager.swift in Sources */,
+				709D1818258699840002E772 /* ParseRemoteDelegate.swift in Sources */,
+				916570D72462DABC008F2997 /* ParseRemote.swift in Sources */,
 				9119D60724561A28001B7AA3 /* CarePlan.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/gavirawson-apple/CareKit",
+        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
-          "branch": "main",
-          "revision": "833fe88e7e96884a52ed173ed4a2a7875a49974d",
+          "branch": null,
+          "revision": "0c0cbe3abd2f0a1fd788a857f137d1726f0940f2",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "453ebdbcddf30cf3baad6bcf79fbc1fc0ba07fe2",
-          "version": "1.2.2"
+          "revision": "a233682449b6053810c5af523d02788c6d348660",
+          "version": "1.2.4"
         }
       }
     ]

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
+        "repositoryURL": "https://github.com/gavirawson-apple/CareKit",
         "state": {
-          "branch": null,
-          "revision": "6e7efbe17c6a4112c54abb7bf9c6387a0d2b132f",
+          "branch": "main",
+          "revision": "833fe88e7e96884a52ed173ed4a2a7875a49974d",
           "version": null
         }
       },

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ ParseCareKitUtility.setupServer() //Pulls from ParseCareKit.plist to connect to 
 ```
 
 ## What version of ParseCareKit Suits Your Needs?
-- (Most cases) Need to use ParseCareKit for iOS13+ and/or watchOS7 and will be using the latest (the minimal required commit is from [PR #508](https://github.com/carekit-apple/CareKit/commit/248c42c4e4ea97ff5fe349361fa6e0a849eab204)) [CareKit 2.1](https://github.com/carekit-apple/CareKit#carekit-), [CareKitUI](https://github.com/carekit-apple/CareKit#carekitui-), and [CareKitStore](https://github.com/carekit-apple/CareKit#carekitstore-) (using `OCKStore`) within your app? You should use the [main](https://github.com/netreconlab/ParseCareKit) branch. You can take advantage of all of the capabilities of ParseCareKit. You should use `ParseRemoteSynchronizationManager()` see [below](#synchronizing-your-data) more details. This branch uses the [Parse-Swift SDK](https://github.com/parse-community/Parse-Swift) instead of the [Parse-Objc SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX).
+- (Most cases) Need to use ParseCareKit for iOS13+ and/or watchOS7 and will be using the latest (the minimal required commit is from [PR #508](https://github.com/carekit-apple/CareKit/commit/248c42c4e4ea97ff5fe349361fa6e0a849eab204)) [CareKit 2.1](https://github.com/carekit-apple/CareKit#carekit-), [CareKitUI](https://github.com/carekit-apple/CareKit#carekitui-), and [CareKitStore](https://github.com/carekit-apple/CareKit#carekitstore-) (using `OCKStore`) within your app? You should use the [main](https://github.com/netreconlab/ParseCareKit) branch. You can take advantage of all of the capabilities of ParseCareKit. You should use `ParseRemote()` see [below](#synchronizing-your-data) more details. This branch uses the [Parse-Swift SDK](https://github.com/parse-community/Parse-Swift) instead of the [Parse-Objc SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX).
 - Need to use ParseCareKit for iOS13+ and/or watchOS7 and will be using the latest [CareKit](https://github.com/carekit-apple/CareKit#carekit-), [CareKitUI](https://github.com/carekit-apple/CareKit#carekitui-), and [CareKitStore](https://github.com/carekit-apple/CareKit#carekitstore-) (but you would like to use the [Parse Objc SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX)) within your app? You will need to use Cocoapods and the [Parse-Objc SDK](https://github.com/netreconlab/ParseCareKit/tree/parse-objc) branch. You can still use all of the capabilities of ParseCareKit. You should use `ParseSynchronizedStoreManager()` see [here](https://github.com/netreconlab/ParseCareKit/tree/parse-objc#synchronizing-your-data) for more details.
 - Need to use ParseCareKit for iOS13+ and will be using [CareKit <= 2.0.1](https://github.com/carekit-apple/CareKit#carekit-), [CareKitUI <= 2.0.1](https://github.com/carekit-apple/CareKit#carekitui-), and [CareKitStore <= 2.0.1](https://github.com/carekit-apple/CareKit#carekitstore-) (using `OCKStore` or conforming to `OCKAnyStoreProtocol`) within your app? You should use the [carekit_2.0.1](https://github.com/netreconlab/ParseCareKit/tree/carekit_2.0.1) branch. You can still use most of the capabilities of ParseCareKit, but you will be limited to syncing via a "wall clock" instead of "knowledge vectors". You will also have to use the [Parse Objc SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX)) and Cocoapods. You should use `ParseSynchronizedStoreManager()` see [here](https://github.com/netreconlab/ParseCareKit/tree/carekit_2.0.1#synchronizing-your-data) for more details.
 
-**Note that it is recommended to use Vectors Clocks (`ParseRemoteSynchronizationManager`) over Wall Clocks (`ParseSynchronizedStoreManager`) as the latter can run into more synching issues. If you choose to go the wall clock route, I recommend having your application suited for 1 device per user to reduce potential synching issues. You can learn more about how vector clocks work by looking at [vector clocks](https://en.wikipedia.org/wiki/Vector_clock).**
+**Note that it is recommended to use Vectors Clocks (`ParseRemote`) over Wall Clocks (`ParseSynchronizedStoreManager`) as the latter can run into more synching issues. If you choose to go the wall clock route, I recommend having your application suited for 1 device per user to reduce potential synching issues. You can learn more about how vector clocks work by looking at [vector clocks](https://en.wikipedia.org/wiki/Vector_clock).**
 
 ## Install ParseCareKit
 
@@ -91,7 +91,7 @@ When giving access to a CareTeam or other entities, special care should be taken
 ## Synchronizing Your Data
 Assuming you are already familiar with [CareKit](https://github.com/carekit-apple/CareKit) (look at their documentation for details). Using ParseCareKit is simple, especially if you are using `OCKStore` out-of-the-box. If you are using a custom `OCKStore` you will need to subclass and write some additional code to synchronize your care-store with parse-server.
 
-### Using vector clocks aka CareKit's KnowledgeVector (`ParseRemoteSynchronizationManager`)
+### Using vector clocks aka CareKit's KnowledgeVector (`ParseRemote`)
 
 ParseCareKit stays synchronized with the `OCKStore` by leveraging `OCKRemoteSynchronizable`.  I recommend having this as a singleton, as it can handle all syncs from the carestore. An example is below:
 
@@ -99,13 +99,13 @@ ParseCareKit stays synchronized with the `OCKStore` by leveraging `OCKRemoteSync
 /*Use Clock and OCKRemoteSynchronizable to keep data synced. 
 This works with 1 or many devices per patient.*/
 let uuid = UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!
-let remoteStoreManager = ParseRemoteSynchronizationManager(uuid: uuid, auto: true)
+let remoteStoreManager = ParseRemote(uuid: uuid, auto: true)
 let dataStore = OCKStore(name: "myDataStore", type: .onDisk, remote: remoteStoreManager)
 remoteStoreManager.delegate = self //Conform to this protocol if you are writing custom CloudCode in Parse and want to push syncs
 remoteStoreManager.parseRemoteDelegate = self //Conform to this protocol to resolve conflicts
 ```
 
-The `uuid` being passed to `ParseRemoteSynchronizationManager` is used for the Clock. A possibile solution that allows for high flexibity is to have 1 of these per user-type per user. This allows you to have have one `ParseUser` that can be a "Doctor" and a "Patient". You should generate a different uuid for this particular ParseUser's `Doctor` and `Patient` type. You can save all types to ParseUser:
+The `uuid` being passed to `ParseRemote` is used for the Clock. A possibile solution that allows for high flexibity is to have 1 of these per user-type per user. This allows you to have have one `ParseUser` that can be a "Doctor" and a "Patient". You should generate a different uuid for this particular ParseUser's `Doctor` and `Patient` type. You can save all types to ParseUser:
 
 ```swift
 let userTypeUUIDDictionary = [
@@ -124,7 +124,7 @@ let userTypeUUIDString = PCKUser.current.userTypes[lastLoggedInType] as! String
 let userTypeUUID = UUID(uuidString: userTypeUUID)!
 
 //Start synching 
-let remoteStoreManager = ParseRemoteSynchronizationManager(uuid: userTypeUUID, auto: true)
+let remoteStoreManager = ParseRemote(uuid: userTypeUUID, auto: true)
 let dataStore = OCKStore(name: "myDataStore", type: .onDisk, remote: remoteStoreManager)
 remoteStoreManager.delegate = self //Conform to this protocol if you are writing custom CloudCode in Parse and want to push syncs
 remoteStoreManager.parseRemoteDelegate = self //Conform to this protocol to resolve conflicts
@@ -134,7 +134,7 @@ Register as a delegate just in case ParseCareKit needs your application to updat
 
 
 ```swift
-extension AppDelegate: OCKRemoteSynchronizationDelegate, ParseRemoteSynchronizationDelegate{
+extension AppDelegate: OCKRemoteSynchronizationDelegate, ParseRemoteDelegate{
     func didRequestSynchronization(_ remote: OCKRemoteSynchronizable) {
         print("Implement so ParseCareKit can tell your OCKStore to sync to the cloud")
         //example
@@ -192,7 +192,7 @@ let updatedConcreteClasses: [PCKStoreClass: PCKSynchronizable] = [
     .patient: CancerPatient()
 ]
 
-remoteStoreManager = ParseRemoteSynchronizationManager(uuid: uuid, auto: true, replacePCKStoreClasses: updatedConcreteClasses)
+remoteStoreManager = ParseRemote(uuid: uuid, auto: true, replacePCKStoreClasses: updatedConcreteClasses)
 dataStore = OCKStore(name: storeName, type: .onDisk(), remote: remoteStoreManager)
 remoteStoreManager.delegate = self
 remoteStoreManager.parseRemoteDelegate = self

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -116,7 +116,7 @@ public struct CarePlan: PCKVersionable {
     public func addToCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
 
         let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -155,7 +155,7 @@ public struct CarePlan: PCKVersionable {
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -211,7 +211,7 @@ public struct CarePlan: PCKVersionable {
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -78,7 +78,7 @@ struct Clock: ParseObject {
 
         //Fetch Clock from Cloud
         let query = Clock.query(ClockKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 

--- a/Sources/ParseCareKit/Objects/Contact.swift
+++ b/Sources/ParseCareKit/Objects/Contact.swift
@@ -149,7 +149,7 @@ public struct Contact: PCKVersionable {
 
         //Check to see if already in the cloud
         let query = Contact.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -186,7 +186,7 @@ public struct Contact: PCKVersionable {
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Contact.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -242,7 +242,7 @@ public struct Contact: PCKVersionable {
         let query = Contact.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 

--- a/Sources/ParseCareKit/Objects/HealthKitTask.swift
+++ b/Sources/ParseCareKit/Objects/HealthKitTask.swift
@@ -130,7 +130,7 @@ public struct HealthKitTask: PCKVersionable {
 
         //Check to see if already in the cloud
         let query = Task.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -168,7 +168,7 @@ public struct HealthKitTask: PCKVersionable {
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = HealthKitTask.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -222,7 +222,7 @@ public struct HealthKitTask: PCKVersionable {
         let query = HealthKitTask.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let tasks):

--- a/Sources/ParseCareKit/Objects/Outcome.swift
+++ b/Sources/ParseCareKit/Objects/Outcome.swift
@@ -140,7 +140,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
 
         //Check to see if already in the cloud
         let query = Outcome.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -177,7 +177,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Self.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -233,7 +233,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let outcomes):
@@ -345,7 +345,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
     }
 
     public func save(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        self.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        self.save(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let saved):
@@ -360,7 +360,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
                     switch result {
 
                     case .success(let linkedObject):
-                        linkedObject.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { _ in }
+                        linkedObject.save(callbackQueue: ParseRemote.queue) { _ in }
                         completion(.success(linkedObject))
 
                     case .failure:
@@ -449,7 +449,7 @@ public struct Outcome: PCKVersionable, PCKSynchronizable {
 
     public func findOutcomesInBackground(completion: @escaping([Outcome]?, Error?) -> Void) {
         let query = Self.queryNotDeleted()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 

--- a/Sources/ParseCareKit/Objects/Patient.swift
+++ b/Sources/ParseCareKit/Objects/Patient.swift
@@ -111,7 +111,7 @@ public struct Patient: PCKVersionable {
 
         //Check to see if already in the cloud
         let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -149,7 +149,7 @@ public struct Patient: PCKVersionable {
         //Check to see if this entity is already in the Cloud, but not paired locally
         let query = Patient.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -201,7 +201,7 @@ public struct Patient: PCKVersionable {
         let query = Self.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let carePlans):

--- a/Sources/ParseCareKit/Objects/Task.swift
+++ b/Sources/ParseCareKit/Objects/Task.swift
@@ -127,7 +127,7 @@ public struct Task: PCKVersionable {
 
         //Check to see if already in the cloud
         let query = Task.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -165,7 +165,7 @@ public struct Task: PCKVersionable {
         //Check to see if this entity is already in the Cloud, but not matched locally
         let query = Task.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 
@@ -219,7 +219,7 @@ public struct Task: PCKVersionable {
         let query = Task.query(ObjectableKey.logicalClock >= localClock)
             .order([.ascending(ObjectableKey.logicalClock), .ascending(ParseKey.createdAt)])
             .includeAll()
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let tasks):

--- a/Sources/ParseCareKit/ParseCareKitError.swift
+++ b/Sources/ParseCareKit/ParseCareKitError.swift
@@ -22,6 +22,7 @@ enum ParseCareKitError: Error {
     case cantCastToNeededClassType
     case classTypeNotAnEligibleType
     case couldntCreateConcreteClasses
+    case syncAlreadyInProgress
 }
 
 extension ParseCareKitError: LocalizedError {
@@ -61,6 +62,8 @@ extension ParseCareKitError: LocalizedError {
         case .objectNotFoundOnParseServer:
             return NSLocalizedString("Object couldn't be found on the Parse Server",
                                      comment: "Object couldn't be found on the Parse Server")
+        case .syncAlreadyInProgress:
+            return NSLocalizedString("Sync already in progress!", comment: "Sync already in progress!")
         }
     }
 }

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -1,5 +1,5 @@
 //
-//  ParseRemoteSynchronizationManager.swift
+//  ParseRemote.swift
 //  ParseCareKit
 //
 //  Created by Corey Baker on 5/6/20.
@@ -14,13 +14,13 @@ import os.log
 // swiftlint:disable line_length
 
 /// Allows the CareKitStore to synchronize against a Parse Server.
-public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
+public class ParseRemote: OCKRemoteSynchronizable {
 
     public weak var delegate: OCKRemoteSynchronizationDelegate?
 
     /// If set, the delegate will be alerted to important events delivered by the remote
     /// store (set this, don't set `delegate`).
-    public weak var parseRemoteDelegate: ParseRemoteSynchronizationDelegate? {
+    public weak var parseRemoteDelegate: ParseRemoteDelegate? {
         get {
             return parseDelegate
         }
@@ -42,7 +42,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
     /// are `Patient`, `Task`, `CarePlan`, `Contact`, and `Outcome`.
     public var pckStoreClassesToSynchronize: [PCKStoreClass: PCKSynchronizable]!
 
-    private weak var parseDelegate: ParseRemoteSynchronizationDelegate?
+    private weak var parseDelegate: ParseRemoteDelegate?
     private var clockSubscription: SubscriptionCallback<Clock>?
     private var subscribeToServerUpdates: Bool
     static let queue = DispatchQueue(label: "edu.netreconlab.parsecarekit",
@@ -51,7 +51,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                                                      autoreleaseFrequency: .inherit,
                                                      target: nil)
     /**
-     Creates an instance of ParseRemoteSynchronizationManager.
+     Creates an instance of ParseRemote.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
@@ -70,7 +70,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
     }
 
     /**
-     Creates an instance of ParseRemoteSynchronizationManager.
+     Creates an instance of ParseRemote.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
@@ -86,7 +86,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
     }
 
     /**
-     Creates an instance of ParseRemoteSynchronizationManager.
+     Creates an instance of ParseRemote.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
@@ -166,7 +166,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
 
             let localClock = knowledgeVector.clock(for: self.uuid)
             self.subscribeToClock()
-            ParseRemoteSynchronizationManager.queue.sync {
+            ParseRemote.queue.sync {
                 self.pullRevisionsForConcreteClasses(previousError: returnError, localClock: localClock,
                                                      cloudVector: cloudVector,
                                                      mergeRevision: mergeRevision) { previosError in
@@ -306,7 +306,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             return
         }
 
-        ParseRemoteSynchronizationManager.queue.async {
+        ParseRemote.queue.async {
             //Fetch Clock from Cloud
             Clock.fetchFromCloud(uuid: self.uuid, createNewIfNeeded: true) { (potentialPCKClock, potentialCKClock, error) in
 
@@ -329,7 +329,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         case .internalServer, .objectNotFound:
                             //1 - this column hasn't been added. 101 - Query returned no results
                             if potentialPCKClock != nil {
-                                potentialPCKClock!.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { _ in
+                                potentialPCKClock!.save(callbackQueue: ParseRemote.queue) { _ in
                                     if #available(iOS 14.0, watchOS 7.0, *) {
                                         Logger.pushRevisions.error("Saved Clock. Try to sync again \(potentialPCKClock!.debugDescription, privacy: .private).")
                                     } else {
@@ -611,7 +611,7 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
             completion(ParseCareKitError.couldntUnwrapClock)
             return
         }
-        parseClock.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        parseClock.save(callbackQueue: ParseRemote.queue) { result in
             switch result {
 
             case .success:

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -45,6 +45,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
     private weak var parseDelegate: ParseRemoteDelegate?
     private var clockSubscription: SubscriptionCallback<Clock>?
     private var subscribeToServerUpdates: Bool
+    private var isSynchronizing = false
     static let queue = DispatchQueue(label: "edu.netreconlab.parsecarekit",
                                                      qos: .default,
                                                      attributes: .concurrent,
@@ -152,6 +153,12 @@ public class ParseRemote: OCKRemoteSynchronizable {
             completion(ParseCareKitError.requiredValueCantBeUnwrapped)
             return
         }
+
+        if isSynchronizing {
+            completion(ParseCareKitError.syncAlreadyInProgress)
+            return
+        }
+        isSynchronizing = true
 
         //Fetch Clock from Cloud
         Clock.fetchFromCloud(uuid: self.uuid, createNewIfNeeded: false) { (_, potentialCKClock, _) in
@@ -612,6 +619,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
             return
         }
         parseClock.save(callbackQueue: ParseRemote.queue) { result in
+            self.isSynchronizing = false
             switch result {
 
             case .success:

--- a/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
+++ b/Sources/ParseCareKit/ParseRemoteSynchronizationManager.swift
@@ -360,10 +360,10 @@ public class ParseRemoteSynchronizationManager: OCKRemoteSynchronizable {
                         let ratioComplete = Double(revisionsCompletedCount)/Double(deviceRevision.entities.count)
                         self.parseDelegate?.remote(self, didUpdateProgress: ratioComplete)
                         if #available(iOS 14.0, watchOS 7.0, *) {
-                            Logger.pullRevisions.info("pushRevisions progress: \(ratioComplete, privacy: .private)")
+                            Logger.pushRevisions.info("pushRevisions progress: \(ratioComplete, privacy: .private)")
                         } else {
                             os_log("pushRevisions progress: %{private}@.",
-                                   log: .pullRevisions, type: .default, ratioComplete)
+                                   log: .pushRevisions, type: .default, ratioComplete)
                         }
                     }
                     let entity = $0

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -147,7 +147,7 @@ extension PCKObjectable {
 
         let query = Self.query(ObjectableKey.uuid == uuidString)
             .includeAll()
-        query.first(callbackQueue: ParseRemoteSynchronizationManager.queue) { result in
+        query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
 
@@ -185,7 +185,7 @@ extension PCKObjectable {
 
         let query = Self.query(ObjectableKey.uuid == uuidString)
             .include([ObjectableKey.notes])
-        query.find(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        query.find(callbackQueue: ParseRemote.queue) { results in
 
             switch results {
 

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -66,7 +66,7 @@ extension PCKVersionable {
 
                         if !previousFound.nextVersionUUIDs.contains(versionFixed.uuid) {
                             previousFound.nextVersionUUIDs.append(versionFixed.uuid)
-                            previousFound.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+                            previousFound.save(callbackQueue: ParseRemote.queue) { results in
                                 switch results {
 
                                 case .success:
@@ -98,7 +98,7 @@ extension PCKVersionable {
                     case .success(var nextFound):
                         if !nextFound.previousVersionUUIDs.contains(versionFixed.uuid) {
                             nextFound.previousVersionUUIDs.append(versionFixed.uuid)
-                            nextFound.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+                            nextFound.save(callbackQueue: ParseRemote.queue) { results in
 
                                 switch results {
 
@@ -132,7 +132,7 @@ extension PCKVersionable {
      It should have the following argument signature: `(Result<PCKSynchronizable,Error>)`.
     */
     public func save(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-        self.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+        self.save(callbackQueue: ParseRemote.queue) { results in
             switch results {
 
             case .success(let savedObject):
@@ -149,7 +149,7 @@ extension PCKVersionable {
                         if case var .success(previousObject) = result {
                             if !previousObject.nextVersionUUIDs.contains(self.uuid) {
                                 previousObject.nextVersionUUIDs.append(self.uuid)
-                                previousObject.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+                                previousObject.save(callbackQueue: ParseRemote.queue) { results in
                                     switch results {
 
                                     case .success:
@@ -174,7 +174,7 @@ extension PCKVersionable {
                         if case var .success(nextObject) = result {
                             if !nextObject.previousVersionUUIDs.contains(self.uuid) {
                                 nextObject.previousVersionUUIDs.append(self.uuid)
-                                nextObject.save(callbackQueue: ParseRemoteSynchronizationManager.queue) { results in
+                                nextObject.save(callbackQueue: ParseRemote.queue) { results in
                                     switch results {
 
                                     case .success:

--- a/Sources/ParseCareKit/Protocols/ParseRemoteDelegate.swift
+++ b/Sources/ParseCareKit/Protocols/ParseRemoteDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  ParseRemoteSynchronizationDelegate.swift
+//  ParseRemoteDelegate.swift
 //  ParseCareKit
 //
 //  Created by Corey Baker on 12/13/20.
@@ -10,10 +10,10 @@ import Foundation
 import CareKitStore
 
 /**
- Objects that conform to the `ParseRemoteSynchronizationDelegate` protocol are
+ Objects that conform to the `ParseRemoteDelegate` protocol are
  able to respond to updates and resolve conflicts when needed.
 */
-public protocol ParseRemoteSynchronizationDelegate: OCKRemoteSynchronizationDelegate {
+public protocol ParseRemoteDelegate: OCKRemoteSynchronizationDelegate {
     /// When a conflict occurs, decide if the device or cloud record should be kept.
     func chooseConflictResolution(conflicts: [OCKEntity], completion: @escaping OCKResultClosure<OCKEntity>)
 
@@ -21,6 +21,6 @@ public protocol ParseRemoteSynchronizationDelegate: OCKRemoteSynchronizationDele
     func successfullyPushedDataToCloud()
 }
 
-extension ParseRemoteSynchronizationDelegate {
+extension ParseRemoteDelegate {
     func successfullyPushedDataToCloud() { }
 }

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -74,7 +74,7 @@ func userLoginToRealServer() {
 // swiftlint:disable:next type_body_length
 class ParseCareKitTests: XCTestCase {
 
-    private var parse: ParseRemoteSynchronizationManager!
+    private var parse: ParseRemote!
     private var store: OCKStore!
 
     override func setUpWithError() throws {
@@ -89,9 +89,9 @@ class ParseCareKitTests: XCTestCase {
         //userLogin()
         //userLoginToRealServer()
         do {
-        parse = try ParseRemoteSynchronizationManager(uuid:
-                                                        // swiftlint:disable:next line_length
-                                                        UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: false, subscribeToServerUpdates: false)
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
         } catch {
             print(error.localizedDescription)
         }
@@ -963,7 +963,7 @@ class ParseCareKitTests: XCTestCase {
     }*/
 }
 
-extension ParseCareKitTests: ParseRemoteSynchronizationDelegate {
+extension ParseCareKitTests: ParseRemoteDelegate {
     func didRequestSynchronization(_ remote: OCKRemoteSynchronizable) {
         print("Implement")
     }


### PR DESCRIPTION
- [x] Renamed `ParseRemoteSynchronizationManager` -> `ParseRemote`
- [x] Renamed `ParseRemoteSynchronizationDelegate` ->  `ParseRemoteDelegate` 
- [x] Updated ParseSwift dependency
- [x] Fix errors on first sync 
- [x]  Updated CareKit dependency
- [x] os_log nits