### PR TITLE
Fix outcome value in CareKit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/erik-apple/CareKit.git",
+        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
           "branch": null,
-          "revision": "53550180b52a4050b7a20cc4372d405764056c6c",
+          "revision": "905a59117c0f63cdeb01db8eddc5e89a30e94eb5",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit",
+        "repositoryURL": "https://github.com/erik-apple/CareKit.git",
         "state": {
           "branch": null,
-          "revision": "0c0cbe3abd2f0a1fd788a857f137d1726f0940f2",
+          "revision": "53550180b52a4050b7a20cc4372d405764056c6c",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "a233682449b6053810c5af523d02788c6d348660",
-          "version": "1.2.4"
+          "revision": "f3f22444e7b15fd2d248bfb4fd1244edb76ed748",
+          "version": "1.2.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "CareKit", url: "https://github.com/erik-apple/CareKit.git",
-                 .revision("53550180b52a4050b7a20cc4372d405764056c6c")),
+        .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit.git",
+                 .revision("905a59117c0f63cdeb01db8eddc5e89a30e94eb5")),
         .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.2.4")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit",
-                 .revision("0c0cbe3abd2f0a1fd788a857f137d1726f0940f2")),
+        .package(name: "CareKit", url: "https://github.com/erik-apple/CareKit.git",
+                 .revision("53550180b52a4050b7a20cc4372d405764056c6c")),
         .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.2.4")
     ],
     targets: [

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
-		7019B3E6260FA209004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B3E5260FA209004E4A3A /* CareKitStore */; };
-		7019B3EA260FA217004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B3E9260FA217004E4A3A /* CareKitStore */; };
+		7019B4892612691B004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B4882612691B004E4A3A /* CareKitStore */; };
+		7019B48D2612692B004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B48C2612692B004E4A3A /* CareKitStore */; };
 		705DC9222526A4B80035BBE3 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
@@ -165,7 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7019B3EA260FA217004E4A3A /* CareKitStore in Frameworks */,
+				7019B48D2612692B004E4A3A /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,7 +174,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7019B3E6260FA209004E4A3A /* CareKitStore in Frameworks */,
+				7019B4892612691B004E4A3A /* CareKitStore in Frameworks */,
 				7075542D255D899E00172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -421,7 +421,7 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
-				7019B3E9260FA217004E4A3A /* CareKitStore */,
+				7019B48C2612692B004E4A3A /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -445,7 +445,7 @@
 			name = ParseCareKit;
 			packageProductDependencies = (
 				7075542C255D899E00172F6B /* ParseSwift */,
-				7019B3E5260FA209004E4A3A /* CareKitStore */,
+				7019B4882612691B004E4A3A /* CareKitStore */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -487,7 +487,7 @@
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
 				7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */,
-				7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */,
+				7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1032,12 +1032,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */ = {
+		7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
+			repositoryURL = "https://github.com/erik-apple/CareKit.git";
 			requirement = {
-				kind = revision;
-				revision = 0c0cbe3abd2f0a1fd788a857f137d1726f0940f2;
+				branch = "fix-558";
+				kind = branch;
 			};
 		};
 		7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
@@ -1051,14 +1051,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7019B3E5260FA209004E4A3A /* CareKitStore */ = {
+		7019B4882612691B004E4A3A /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
+			package = 7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
 		};
-		7019B3E9260FA217004E4A3A /* CareKitStore */ = {
+		7019B48C2612692B004E4A3A /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7019B3E4260FA209004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
+			package = 7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
 		};
 		7075542C255D899E00172F6B /* ParseSwift */ = {

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700775A92522686D00EC0EDA /* PCKVersionable.swift */; };
-		7019B4892612691B004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B4882612691B004E4A3A /* CareKitStore */; };
-		7019B48D2612692B004E4A3A /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 7019B48C2612692B004E4A3A /* CareKitStore */; };
 		705DC9222526A4B80035BBE3 /* ParseCareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */; };
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
@@ -32,6 +30,7 @@
 		709D1818258699840002E772 /* ParseRemoteDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteDelegate.swift */; };
 		709D1819258699840002E772 /* ParseRemoteDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteDelegate.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
+		70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD4261286270056DE0C /* CareKitStore */; };
 		70D5A29425E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
@@ -165,7 +164,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7019B48D2612692B004E4A3A /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,7 +172,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7019B4892612691B004E4A3A /* CareKitStore in Frameworks */,
+				70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */,
 				7075542D255D899E00172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -421,7 +419,6 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
-				7019B48C2612692B004E4A3A /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -445,7 +442,7 @@
 			name = ParseCareKit;
 			packageProductDependencies = (
 				7075542C255D899E00172F6B /* ParseSwift */,
-				7019B4882612691B004E4A3A /* CareKitStore */,
+				70C0AFD4261286270056DE0C /* CareKitStore */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -487,7 +484,7 @@
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
 				7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */,
-				7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */,
+				70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1032,14 +1029,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/erik-apple/CareKit.git";
-			requirement = {
-				branch = "fix-558";
-				kind = branch;
-			};
-		};
 		7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
@@ -1048,19 +1037,17 @@
 				minimumVersion = 1.2.4;
 			};
 		};
+		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
+			requirement = {
+				kind = revision;
+				revision = 905a59117c0f63cdeb01db8eddc5e89a30e94eb5;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7019B4882612691B004E4A3A /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
-		};
-		7019B48C2612692B004E4A3A /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7019B4872612691B004E4A3A /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
-		};
 		7075542C255D899E00172F6B /* ParseSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
@@ -1070,6 +1057,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
 			productName = ParseSwift;
+		};
+		70C0AFD4261286270056DE0C /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		709D1819258699840002E772 /* ParseRemoteDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709D1817258699840002E772 /* ParseRemoteDelegate.swift */; };
 		70B326BE251EBE610028B229 /* PCKUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B326BD251EBE610028B229 /* PCKUser.swift */; };
 		70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD4261286270056DE0C /* CareKitStore */; };
+		70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD826128D9D0056DE0C /* CareKitStore */; };
 		70D5A29425E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* HealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* HealthKitTask.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
@@ -164,6 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */,
 				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -419,6 +421,7 @@
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
 				70755430255D89B800172F6B /* ParseSwift */,
+				70C0AFD826128D9D0056DE0C /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -1059,6 +1062,11 @@
 			productName = ParseSwift;
 		};
 		70C0AFD4261286270056DE0C /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
+		};
+		70C0AFD826128D9D0056DE0C /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
+        "repositoryURL": "https://github.com/erik-apple/CareKit.git",
         "state": {
-          "branch": null,
-          "revision": "0c0cbe3abd2f0a1fd788a857f137d1726f0940f2",
+          "branch": "fix-558",
+          "revision": "53550180b52a4050b7a20cc4372d405764056c6c",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "a233682449b6053810c5af523d02788c6d348660",
-          "version": "1.2.4"
+          "revision": "f3f22444e7b15fd2d248bfb4fd1244edb76ed748",
+          "version": "1.2.5"
         }
       }
     ]

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/erik-apple/CareKit.git",
+        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
-          "branch": "fix-558",
-          "revision": "53550180b52a4050b7a20cc4372d405764056c6c",
+          "branch": null,
+          "revision": "905a59117c0f63cdeb01db8eddc5e89a30e94eb5",
           "version": null
         }
       },

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -309,6 +309,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
 
         guard deviceRevision.entities.count > 0 else {
             //No revisions need to be pushed
+            self.isSynchronizing = false
             completion(nil)
             return
         }


### PR DESCRIPTION
- [x] Update to latest CareKit to properly show `OCKOutcomeValues` in views
- [x] Fixed a bug in ParseCareKit that prevented forced syncing after there's no values to push  