### PR TITLE
Update to ParseSwift 1.10.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "ddcf35f54365397f75068744e6ff975e875dd73a",
-          "version": "1.9.10"
+          "revision": "f085dcf10156dedf1bd8dd7bc606837e1fecb5ea",
+          "version": "1.10.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit.git",
                  .revision("64ad91eb9ed25f85dab1079c037bfc7c4029d89b")),
-        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.9.10")
+        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.10.0")
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1041,7 +1041,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.9.10;
+				minimumVersion = 1.10.0;
 			};
 		};
 		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "ddcf35f54365397f75068744e6ff975e875dd73a",
-          "version": "1.9.10"
+          "revision": "f085dcf10156dedf1bd8dd7bc606837e1fecb5ea",
+          "version": "1.10.0"
         }
       }
     ]

--- a/Sources/ParseCareKit/Objects/CarePlan.swift
+++ b/Sources/ParseCareKit/Objects/CarePlan.swift
@@ -20,9 +20,10 @@ import os.log
 /// plan evolves with the patient's progress, the care provider may modify the exercises and include notes each
 /// time about why the changes were made.
 public struct CarePlan: PCKVersionable {
+
     public var effectiveDate: Date?
 
-    public var uuid: UUID
+    public var uuid: UUID?
 
     public var entityId: String?
 
@@ -66,9 +67,9 @@ public struct CarePlan: PCKVersionable {
 
     public var ACL: ParseACL? = try? ParseACL.defaultACL()
 
-    public var nextVersionUUIDs: [UUID]
+    public var nextVersionUUIDs: [UUID]?
 
-    public var previousVersionUUIDs: [UUID]
+    public var previousVersionUUIDs: [UUID]?
 
     /// The patient to whom this care plan belongs.
     public var patient: Patient? {
@@ -97,6 +98,8 @@ public struct CarePlan: PCKVersionable {
         case previousVersionUUIDs, nextVersionUUIDs, effectiveDate
         case title, patient, patientUUID
     }
+
+    public init() { }
 
     public func new(with careKitEntity: OCKEntity) throws -> CarePlan {
         switch careKitEntity {
@@ -149,7 +152,11 @@ public struct CarePlan: PCKVersionable {
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
 
-        var previousVersionUUIDs = self.previousVersionUUIDs
+        guard var previousVersionUUIDs = self.previousVersionUUIDs,
+                let uuid = self.uuid else {
+                    completion(.failure(ParseCareKitError.couldntUnwrapRequiredField))
+            return
+        }
         previousVersionUUIDs.append(uuid)
 
         // Check to see if this entity is already in the Cloud, but not matched locally
@@ -170,7 +177,12 @@ public struct CarePlan: PCKVersionable {
                     self.addToCloud(completion: completion)
                 case 1:
                     // This is the typical case
-                    guard let previousVersion = foundObjects.first(where: { self.previousVersionUUIDs.contains($0.uuid) }) else {
+                    guard let previousVersion = foundObjects.first(where: {
+                        guard let foundUUID = $0.uuid else {
+                            return false
+                        }
+                        return previousVersionUUIDs.contains(foundUUID)
+                    }) else {
                         if #available(iOS 14.0, watchOS 7.0, *) {
                             Logger.carePlan.error("updateCloud(), Didn't find previousVersion of this UUID (\(previousVersionUUIDs, privacy: .private)) already exists in Cloud")
                         } else {

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -24,13 +24,6 @@ struct Clock: ParseObject {
 
     var vector: String?
 
-    public init() { }
-
-    init(uuid: UUID) {
-        self.uuid = uuid
-        self.vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
-    }
-
     func decodeClock(completion:@escaping(OCKRevisionRecord.KnowledgeVector?) -> Void) {
         guard let data = self.vector?.data(using: .utf8) else {
             if #available(iOS 14.0, watchOS 7.0, *) {
@@ -100,5 +93,12 @@ struct Clock: ParseObject {
                 }
             }
         }
+    }
+}
+
+extension Clock {
+    init(uuid: UUID) {
+        self.uuid = uuid
+        self.vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
     }
 }

--- a/Sources/ParseCareKit/Objects/Clock.swift
+++ b/Sources/ParseCareKit/Objects/Clock.swift
@@ -24,6 +24,8 @@ struct Clock: ParseObject {
 
     var vector: String?
 
+    public init() { }
+
     init(uuid: UUID) {
         self.uuid = uuid
         self.vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"

--- a/Sources/ParseCareKit/ParseCareKitError.swift
+++ b/Sources/ParseCareKit/ParseCareKitError.swift
@@ -16,7 +16,8 @@ enum ParseCareKitError: Error {
     case objectNotFoundOnParseServer
     case cloudClockLargerThanLocal
     case couldntUnwrapClock
-    case cantUnwrapSelf
+    case couldntUnwrapRequiredField
+    case couldntUnwrapSelf
     case cloudVersionNewerThanLocal
     case uuidAlreadyExists
     case cantCastToNeededClassType
@@ -36,13 +37,16 @@ extension ParseCareKitError: LocalizedError {
             return NSLocalizedString("ParseCareKit: Required value can't be unwrapped.", comment: "Unwrapping error")
         case .couldntUnwrapClock:
             return NSLocalizedString("ParseCareKit: Clock can't be unwrapped.", comment: "Clock Unwrapping error")
+        case .couldntUnwrapRequiredField:
+            return NSLocalizedString("ParseCareKit: Couldn't unwrap required field.",
+                                     comment: "Couldn't unwrap required field")
         case .objectIdDoesntMatchRemoteId:
             return NSLocalizedString("ParseCareKit: remoteId and objectId don't match.",
                                      comment: "Remote/Local mismatch error")
         case .cloudClockLargerThanLocal:
             return NSLocalizedString("Cloud clock larger than local during pushRevisions, not pushing",
                                      comment: "Knowledge vector larger in Cloud")
-        case .cantUnwrapSelf:
+        case .couldntUnwrapSelf:
             return NSLocalizedString("Can't unwrap self. This class has already been deallocated",
                                      comment: "Can't unwrap self, class deallocated")
         case .cloudVersionNewerThanLocal:

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -19,7 +19,7 @@ import os.log
 */
 public protocol PCKObjectable: ParseObject {
     /// A universally unique identifier for this object.
-    var uuid: UUID { get set }
+    var uuid: UUID? { get set }
 
     /// A human readable unique identifier. It is used strictly by the developer and will never be shown to a user
     var id: String { get }
@@ -110,7 +110,7 @@ extension PCKObjectable {
     /// Stamps all related entities with the current `logicalClock` value
     /*mutating public func stampRelationalEntities() throws -> Self {
         guard let logicalClock = self.logicalClock else {
-            throw ParseCareKitError.cantUnwrapSelf
+            throw ParseCareKitError.couldntUnwrapSelf
         }
         var updatedNotes = [OCKNote]()
         notes?.forEach {


### PR DESCRIPTION
ParseSwift 1.10.0 requires all ParseObjects to have a default initializer, `init()` and all properties to be initialized.