### PR TITLE
fix: delegate not firing when no data is pushed

### DIFF
--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -317,6 +317,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
         guard deviceRevision.entities.count > 0 else {
             // No revisions need to be pushed
             self.isSynchronizing = false
+            self.parseRemoteDelegate?.successfullyPushedDataToCloud()
             completion(nil)
             return
         }


### PR DESCRIPTION
Addresses an issue when the `ParseRemoteDelegate` method `successfullyPushedDataToCloud` wasn't being called when no data was pushed to the remote.