### PR TITLE
feat: improve default ACL support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,10 +4,10 @@ coverage:
   status:
     patch:
       default:
-        target: 0
+        target: auto
     changes: false
     project:
       default:
-        target: 12
+        target: 17
 comment:
   require_changes: true

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "25b70d9a7c939c05a8fe86abfe375ebcba081e75",
-          "version": "2.2.4"
+          "revision": "b4bdfb12ee980add480fcf30ddcead5a49509a72",
+          "version": "2.2.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit.git",
                  .revision("a612482e4ba4f28d4c75129c0a9b70ca23098bd6")),
-        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "2.2.4")
+        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "2.2.6")
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -87,6 +87,13 @@
 			remoteGlobalIDString = 9119D5EA245618D7001B7AA3;
 			remoteInfo = ParseCareKit;
 		};
+		91226D4E274A931400B5C2DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9119D5E2245618D7001B7AA3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 709752DF250D27300020EA70;
+			remoteInfo = TestHost;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -398,6 +405,7 @@
 			);
 			dependencies = (
 				705DC9242526A4B80035BBE3 /* PBXTargetDependency */,
+				91226D4F274A931400B5C2DF /* PBXTargetDependency */,
 			);
 			name = ParseCareKitTests;
 			productName = ParseCareKitTests;
@@ -482,6 +490,7 @@
 				TargetAttributes = {
 					705DC91C2526A4B80035BBE3 = {
 						CreatedOnToolsVersion = 12.0.1;
+						TestTargetID = 709752DF250D27300020EA70;
 					};
 					709752DF250D27300020EA70 = {
 						CreatedOnToolsVersion = 11.7;
@@ -685,6 +694,11 @@
 			target = 9119D5EA245618D7001B7AA3 /* ParseCareKit */;
 			targetProxy = 709752FC250D351B0020EA70 /* PBXContainerItemProxy */;
 		};
+		91226D4F274A931400B5C2DF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 709752DF250D27300020EA70 /* TestHost */;
+			targetProxy = 91226D4E274A931400B5C2DF /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -702,6 +716,7 @@
 		705DC9252526A4B80035BBE3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ParseCareKitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -714,12 +729,14 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 			};
 			name = Debug;
 		};
 		705DC9262526A4B80035BBE3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ParseCareKitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -732,6 +749,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 			};
 			name = Release;
 		};
@@ -1068,7 +1086,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.4;
+				minimumVersion = 2.2.6;
 			};
 		};
 		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -72,6 +72,12 @@
 		91226D58274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */; };
 		91226D5A274AC23300B5C2DF /* OCKOutcome+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */; };
 		91226D5C274AC24A00B5C2DF /* OCKTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */; };
+		91226D5D274AD9B600B5C2DF /* OCKCarePlan+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D53274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift */; };
+		91226D5E274AD9B600B5C2DF /* OCKContact+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D55274AC1EF00B5C2DF /* OCKContact+Parse.swift */; };
+		91226D5F274AD9B600B5C2DF /* OCKHealthKitTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */; };
+		91226D60274AD9B600B5C2DF /* OCKOutcome+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */; };
+		91226D61274AD9B600B5C2DF /* OCKPatient+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */; };
+		91226D62274AD9B600B5C2DF /* OCKTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */; };
 		916570D72462DABC008F2997 /* ParseRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemote.swift */; };
 		918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		91AA07232466F0CD00B39452 /* PCKClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA07222466F0CD00B39452 /* PCKClock.swift */; };
@@ -654,6 +660,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91226D5D274AD9B600B5C2DF /* OCKCarePlan+Parse.swift in Sources */,
+				91226D5E274AD9B600B5C2DF /* OCKContact+Parse.swift in Sources */,
+				91226D5F274AD9B600B5C2DF /* OCKHealthKitTask+Parse.swift in Sources */,
+				91226D60274AD9B600B5C2DF /* OCKOutcome+Parse.swift in Sources */,
+				91226D61274AD9B600B5C2DF /* OCKPatient+Parse.swift in Sources */,
+				91226D62274AD9B600B5C2DF /* OCKTask+Parse.swift in Sources */,
 				709D175E258551D20002E772 /* ParseCareKitLog.swift in Sources */,
 				70F2E187254EFC8000B2EA5C /* ParseCareKitConstants.swift in Sources */,
 				700B0ED7270DD7D900EEF103 /* PCKVersionable+async.swift in Sources */,

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -66,6 +66,12 @@
 		9119D60B24561B02001B7AA3 /* ParseCareKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */; };
 		9119D60D24561B22001B7AA3 /* PCKUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9119D60C24561B22001B7AA3 /* PCKUtility.swift */; };
 		9119D69A245689DA001B7AA3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 9119D699245689D9001B7AA3 /* README.md */; };
+		91226D52274AC00500B5C2DF /* OCKPatient+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */; };
+		91226D54274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D53274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift */; };
+		91226D56274AC1EF00B5C2DF /* OCKContact+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D55274AC1EF00B5C2DF /* OCKContact+Parse.swift */; };
+		91226D58274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */; };
+		91226D5A274AC23300B5C2DF /* OCKOutcome+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */; };
+		91226D5C274AC24A00B5C2DF /* OCKTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */; };
 		916570D72462DABC008F2997 /* ParseRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemote.swift */; };
 		918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		91AA07232466F0CD00B39452 /* PCKClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA07222466F0CD00B39452 /* PCKClock.swift */; };
@@ -159,6 +165,12 @@
 		9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseCareKitConstants.swift; sourceTree = "<group>"; };
 		9119D60C24561B22001B7AA3 /* PCKUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUtility.swift; sourceTree = "<group>"; };
 		9119D699245689D9001B7AA3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKPatient+Parse.swift"; sourceTree = "<group>"; };
+		91226D53274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKCarePlan+Parse.swift"; sourceTree = "<group>"; };
+		91226D55274AC1EF00B5C2DF /* OCKContact+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKContact+Parse.swift"; sourceTree = "<group>"; };
+		91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKHealthKitTask+Parse.swift"; sourceTree = "<group>"; };
+		91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcome+Parse.swift"; sourceTree = "<group>"; };
+		91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKTask+Parse.swift"; sourceTree = "<group>"; };
 		916570D62462DABC008F2997 /* ParseRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemote.swift; sourceTree = "<group>"; };
 		918F07ED247D66C800C3A205 /* PCKObjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKObjectable.swift; sourceTree = "<group>"; };
 		91AA07222466F0CD00B39452 /* PCKClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKClock.swift; sourceTree = "<group>"; };
@@ -328,6 +340,7 @@
 		9119D5ED245618D7001B7AA3 /* ParseCareKit */ = {
 			isa = PBXGroup;
 			children = (
+				91226D50274ABFCF00B5C2DF /* Extensions */,
 				7085DDAC26CDA2980033B977 /* Documentation.docc */,
 				9119D5EE245618D7001B7AA3 /* ParseCareKit.h */,
 				9119D60A24561B02001B7AA3 /* ParseCareKitConstants.swift */,
@@ -340,6 +353,19 @@
 				91D52878248128700022292B /* Protocols */,
 			);
 			path = ParseCareKit;
+			sourceTree = "<group>";
+		};
+		91226D50274ABFCF00B5C2DF /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				91226D53274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift */,
+				91226D55274AC1EF00B5C2DF /* OCKContact+Parse.swift */,
+				91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */,
+				91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */,
+				91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */,
+				91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		918F080B248040AA00C3A205 /* Objects */ = {
@@ -661,19 +687,25 @@
 				700B0ED6270DD7D900EEF103 /* PCKVersionable+async.swift in Sources */,
 				9119D60B24561B02001B7AA3 /* ParseCareKitConstants.swift in Sources */,
 				700B0ED9270DDF5600EEF103 /* PCKObjectable+combine.swift in Sources */,
+				91226D5A274AC23300B5C2DF /* OCKOutcome+Parse.swift in Sources */,
 				9119D60D24561B22001B7AA3 /* PCKUtility.swift in Sources */,
 				700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */,
 				70D5A29425E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */,
 				9119D60324561A28001B7AA3 /* PCKTask.swift in Sources */,
 				9119D60824561A28001B7AA3 /* PCKOutcome.swift in Sources */,
 				709D176B258579090002E772 /* ParseCareKitError.swift in Sources */,
+				91226D5C274AC24A00B5C2DF /* OCKTask+Parse.swift in Sources */,
+				91226D58274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift in Sources */,
 				70B326BE251EBE610028B229 /* PCKUser.swift in Sources */,
 				918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */,
 				700B0EDC270DE0C400EEF103 /* PCKVersionable+combine.swift in Sources */,
 				9119D60124561A28001B7AA3 /* PCKContact.swift in Sources */,
 				91AA07232466F0CD00B39452 /* PCKClock.swift in Sources */,
 				9119D60424561A28001B7AA3 /* PCKPatient.swift in Sources */,
+				91226D52274AC00500B5C2DF /* OCKPatient+Parse.swift in Sources */,
 				7085DDAD26CDA2980033B977 /* Documentation.docc in Sources */,
+				91226D56274AC1EF00B5C2DF /* OCKContact+Parse.swift in Sources */,
+				91226D54274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift in Sources */,
 				91D5287A24813AF70022292B /* PCKSynchronizable.swift in Sources */,
 				709D1818258699840002E772 /* ParseRemoteDelegate.swift in Sources */,
 				916570D72462DABC008F2997 /* ParseRemote.swift in Sources */,
@@ -762,7 +794,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TestHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -784,7 +816,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TestHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -901,7 +933,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -959,7 +991,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 		91226D60274AD9B600B5C2DF /* OCKOutcome+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */; };
 		91226D61274AD9B600B5C2DF /* OCKPatient+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */; };
 		91226D62274AD9B600B5C2DF /* OCKTask+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */; };
+		91226D64274ADCE100B5C2DF /* UtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91226D63274ADCE100B5C2DF /* UtilityTests.swift */; };
+		91226D67274ADD4B00B5C2DF /* ParseCareKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = 91226D66274ADD4B00B5C2DF /* ParseCareKit.plist */; };
+		91226D68274AE59400B5C2DF /* ParseCareKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = 91226D66274ADD4B00B5C2DF /* ParseCareKit.plist */; };
 		916570D72462DABC008F2997 /* ParseRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916570D62462DABC008F2997 /* ParseRemote.swift */; };
 		918F07EE247D66C800C3A205 /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
 		91AA07232466F0CD00B39452 /* PCKClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA07222466F0CD00B39452 /* PCKClock.swift */; };
@@ -177,6 +180,8 @@
 		91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKHealthKitTask+Parse.swift"; sourceTree = "<group>"; };
 		91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKOutcome+Parse.swift"; sourceTree = "<group>"; };
 		91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKTask+Parse.swift"; sourceTree = "<group>"; };
+		91226D63274ADCE100B5C2DF /* UtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTests.swift; sourceTree = "<group>"; };
+		91226D66274ADD4B00B5C2DF /* ParseCareKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ParseCareKit.plist; sourceTree = "<group>"; };
 		916570D62462DABC008F2997 /* ParseRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseRemote.swift; sourceTree = "<group>"; };
 		918F07ED247D66C800C3A205 /* PCKObjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKObjectable.swift; sourceTree = "<group>"; };
 		91AA07222466F0CD00B39452 /* PCKClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKClock.swift; sourceTree = "<group>"; };
@@ -249,6 +254,7 @@
 			children = (
 				7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */,
 				709D18062586903C0002E772 /* LoggerTests.swift */,
+				91226D63274ADCE100B5C2DF /* UtilityTests.swift */,
 				7098A7752524E92900DDF53D /* NetworkMocking */,
 			);
 			path = ParseCareKitTests;
@@ -273,12 +279,13 @@
 		709752E1250D27300020EA70 /* TestHost */ = {
 			isa = PBXGroup;
 			children = (
+				709752F0250D27320020EA70 /* Info.plist */,
+				91226D66274ADD4B00B5C2DF /* ParseCareKit.plist */,
 				709752E2250D27300020EA70 /* AppDelegate.swift */,
-				709752E4250D27300020EA70 /* SceneDelegate.swift */,
 				709752E6250D27300020EA70 /* ContentView.swift */,
+				709752E4250D27300020EA70 /* SceneDelegate.swift */,
 				709752E8250D27320020EA70 /* Assets.xcassets */,
 				709752ED250D27320020EA70 /* LaunchScreen.storyboard */,
-				709752F0250D27320020EA70 /* Info.plist */,
 				709752EA250D27320020EA70 /* Preview Content */,
 			);
 			path = TestHost;
@@ -576,6 +583,7 @@
 				709752EF250D27320020EA70 /* LaunchScreen.storyboard in Resources */,
 				709752EC250D27320020EA70 /* Preview Assets.xcassets in Resources */,
 				709752E9250D27320020EA70 /* Assets.xcassets in Resources */,
+				91226D68274AE59400B5C2DF /* ParseCareKit.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -590,6 +598,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91226D67274ADD4B00B5C2DF /* ParseCareKit.plist in Resources */,
 				9119D69A245689DA001B7AA3 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -639,6 +648,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91226D64274ADCE100B5C2DF /* UtilityTests.swift in Sources */,
 				705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */,
 				705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */,
 				705DC92D2526A5650035BBE3 /* MockURLResponse.swift in Sources */,

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -18,6 +18,15 @@
           "revision": "c91e5bb74397136f79656bebdfda76a523d3e88c",
           "version": "0.3.2"
         }
+      },
+      {
+        "package": "ParseSwift",
+        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "b4bdfb12ee980add480fcf30ddcead5a49509a72",
+          "version": "2.2.6"
+        }
       }
     ]
   },

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -18,15 +18,6 @@
           "revision": "c91e5bb74397136f79656bebdfda76a523d3e88c",
           "version": "0.3.2"
         }
-      },
-      {
-        "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
-        "state": {
-          "branch": null,
-          "revision": "b4bdfb12ee980add480fcf30ddcead5a49509a72",
-          "version": "2.2.6"
-        }
       }
     ]
   },

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "25b70d9a7c939c05a8fe86abfe375ebcba081e75",
-          "version": "2.2.4"
+          "revision": "b4bdfb12ee980add480fcf30ddcead5a49509a72",
+          "version": "2.2.6"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -79,15 +79,20 @@ To install via cocoapods, go to the [Parse-Objc SDK](https://github.com/netrecon
 For details on how to setup parse-server, follow the directions [here](https://github.com/parse-community/parse-server#getting-started) or look at their detailed [guide](https://docs.parseplatform.org/parse-server/guide/). Note that standard deployment locally on compouter, docker, AWS, Google Cloud, isn't HIPAA complaint by default. 
 
 ### Protecting Patients data in the Cloud using ACL's
-`ParseCareKit` will set a default ACL on every object saved to your Parse Server with read/write access only for the user who created the data. If you want different level of access by default, you should set the default ACL you prefer before initializing `ParseCareKit`. For example, to make all data created to only be read and written by the user who created at do the following in your `AppDelegate.swift`:
+`ParseCareKit` will set a default ACL on every object saved to your Parse Server with read/write access only for the user who created the data. If you want different level of access by default, you should pass the default ACL you prefer while initializing `ParseCareKit`. For example, to make all data created to only be read and written by the user who created it, do the following:
 
 ```swift
 //Set default ACL for all Parse Classes
-var defaultACL = ParseACL()
-defaultACL.publicRead = false
-defaultACL.publicWrite = false
+var newACL = ParseACL()
+newACL.publicRead = false
+newACL.publicWrite = false        
+newACL.setReadAccess(user: user, value: true)
+newACL.setWriteAccess(user: user, value: true)
 do {
-    _ = try ParseACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
+    let parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false,
+                                defaultACL: newACL)
 } catch {
     print(error.localizedDescription)
 }

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ let userTypeUUIDDictionary = [
 //Store the possible uuids for each type
 PCKUser.current.userTypes = userTypeUUIDDictionary //Note that you need to save the UUID in string form to Parse
 PCKUser.current.loggedInType = "doctor" 
-PCKUser.current.saveInBackground()
+PCKUser.current.save()
 
 //Start synch with the correct knowlege vector for the particular type of user
 let lastLoggedInType = PCKUser.current.loggedInType

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To install via cocoapods, go to the [Parse-Objc SDK](https://github.com/netrecon
 For details on how to setup parse-server, follow the directions [here](https://github.com/parse-community/parse-server#getting-started) or look at their detailed [guide](https://docs.parseplatform.org/parse-server/guide/). Note that standard deployment locally on compouter, docker, AWS, Google Cloud, isn't HIPAA complaint by default. 
 
 ### Protecting Patients data in the Cloud using ACL's
-You should set the default access for information you placed on your parse-server using ParseCareKit. To do this, you can set the default read/write access for all classes. For example, to make all data created to only be read and written by the user who created at do the following in `AppDelegate.swift`:
+`ParseCareKit` will set a default ACL on every object saved to your Parse Server with read/write access only for the user who created the data. If you want different level of access by default, you should set the default ACL you prefer before initializing `ParseCareKit`. For example, to make all data created to only be read and written by the user who created at do the following in your `AppDelegate.swift`:
 
 ```swift
 //Set default ACL for all Parse Classes

--- a/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKCarePlan {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKCarePlan+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKCarePlan {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKContact+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKContact {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKContact {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKHealthKitTask+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKHealthKitTask {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKHealthKitTask {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKOutcome+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKOutcome {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKOutcome {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKPatient {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKPatient+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKPatient {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
@@ -1,0 +1,40 @@
+//
+//  OCKTask+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+import CareKitStore
+import ParseSwift
+
+public extension OCKTask {
+    /**
+    The Parse ACL for this object.
+    */
+    var acl: ParseACL? {
+        guard let aclString = userInfo?[ParseCareKitConstants.acl],
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? PCKUtility.decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
+
+    /**
+    Set the Parse ACL for this object.
+    */
+    mutating func setACL(_ acl: ParseACL) throws {
+        let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+        guard let aclString = String(data: encodedACL, encoding: .utf8) else {
+            throw ParseCareKitError.cantEncodeACL
+        }
+        if var userInfo = userInfo {
+            userInfo[ParseCareKitConstants.acl] = aclString
+        } else {
+            userInfo = [ParseCareKitConstants.acl: aclString]
+        }
+    }
+}

--- a/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
@@ -25,6 +25,7 @@ public extension OCKTask {
 
     /**
     Set the Parse ACL for this object.
+     - parameter acl: The Parse ACL for this object.
     */
     mutating func setACL(_ acl: ParseACL) throws {
         let encodedACL = try PCKUtility.jsonEncoder().encode(acl)

--- a/Sources/ParseCareKit/Objects/PCKCarePlan.swift
+++ b/Sources/ParseCareKit/Objects/PCKCarePlan.swift
@@ -310,7 +310,11 @@ public struct PCKCarePlan: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(carePlan)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = carePlan.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = carePlan.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKCarePlan.swift
+++ b/Sources/ParseCareKit/Objects/PCKCarePlan.swift
@@ -69,7 +69,7 @@ public struct PCKCarePlan: PCKVersionable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     public var nextVersionUUIDs: [UUID]?
 

--- a/Sources/ParseCareKit/Objects/PCKCarePlan.swift
+++ b/Sources/ParseCareKit/Objects/PCKCarePlan.swift
@@ -103,7 +103,9 @@ public struct PCKCarePlan: PCKVersionable {
         case title, patient, patientUUID
     }
 
-    public init() { }
+    public init() {
+        ACL = PCKUtility.getDefaultACL()
+    }
 
     public func new(with careKitEntity: OCKEntity) throws -> PCKCarePlan {
         switch careKitEntity {
@@ -308,6 +310,7 @@ public struct PCKCarePlan: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(carePlan)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = carePlan.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKClock.swift
+++ b/Sources/ParseCareKit/Objects/PCKClock.swift
@@ -107,6 +107,7 @@ struct PCKClock: ParseObjectMutable {
 extension PCKClock {
     init(uuid: UUID) {
         self.uuid = uuid
-        self.vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
+        vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
+        ACL = PCKUtility.getDefaultACL()
     }
 }

--- a/Sources/ParseCareKit/Objects/PCKContact.swift
+++ b/Sources/ParseCareKit/Objects/PCKContact.swift
@@ -133,7 +133,9 @@ public struct PCKContact: PCKVersionable {
         case emailAddresses, messagingNumbers, phoneNumbers, otherContactInfo
     }
 
-    public init() { }
+    public init() {
+        ACL = PCKUtility.getDefaultACL()
+    }
 
     public func new(with careKitEntity: OCKEntity) throws -> PCKContact {
 
@@ -344,6 +346,7 @@ public struct PCKContact: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(contact)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = contact.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKContact.swift
+++ b/Sources/ParseCareKit/Objects/PCKContact.swift
@@ -346,7 +346,11 @@ public struct PCKContact: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(contact)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = contact.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = contact.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKContact.swift
+++ b/Sources/ParseCareKit/Objects/PCKContact.swift
@@ -73,7 +73,7 @@ public struct PCKContact: PCKVersionable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     /// The contact's postal address.
     public var address: OCKPostalAddress?

--- a/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
@@ -325,7 +325,11 @@ public struct PCKHealthKitTask: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(task)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = task.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
@@ -75,7 +75,7 @@ public struct PCKHealthKitTask: PCKVersionable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     /// A structure specifying how this task is linked with HealthKit.
     public var healthKitLinkage: OCKHealthKitLinkage?

--- a/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
@@ -115,7 +115,9 @@ public struct PCKHealthKitTask: PCKVersionable {
         case title, carePlan, carePlanUUID, impactsAdherence, instructions, schedule, healthKitLinkage
     }
 
-    public init() { }
+    public init() {
+        ACL = PCKUtility.getDefaultACL()
+    }
 
     public func new(with careKitEntity: OCKEntity) throws -> PCKHealthKitTask {
 
@@ -323,6 +325,7 @@ public struct PCKHealthKitTask: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(task)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKOutcome.swift
+++ b/Sources/ParseCareKit/Objects/PCKOutcome.swift
@@ -329,7 +329,11 @@ public struct PCKOutcome: PCKVersionable, PCKSynchronizable {
         let encoded = try PCKUtility.jsonEncoder().encode(outcome)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = outcome.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = outcome.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKOutcome.swift
+++ b/Sources/ParseCareKit/Objects/PCKOutcome.swift
@@ -114,6 +114,7 @@ public struct PCKOutcome: PCKVersionable, PCKSynchronizable {
         uuid = UUID()
         previousVersionUUIDs = []
         nextVersionUUIDs = []
+        ACL = PCKUtility.getDefaultACL()
     }
 
     enum CodingKeys: String, CodingKey {
@@ -328,6 +329,7 @@ public struct PCKOutcome: PCKVersionable, PCKSynchronizable {
         let encoded = try PCKUtility.jsonEncoder().encode(outcome)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = outcome.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKOutcome.swift
+++ b/Sources/ParseCareKit/Objects/PCKOutcome.swift
@@ -70,7 +70,7 @@ public struct PCKOutcome: PCKVersionable, PCKSynchronizable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     var startDate: Date? // Custom added, check if needed
 

--- a/Sources/ParseCareKit/Objects/PCKPatient.swift
+++ b/Sources/ParseCareKit/Objects/PCKPatient.swift
@@ -87,7 +87,9 @@ public struct PCKPatient: PCKVersionable {
         case allergies, birthday, name, sex
     }
 
-    public init() { }
+    public init() {
+        ACL = PCKUtility.getDefaultACL()
+    }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -302,6 +304,7 @@ public struct PCKPatient: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(patient)
         var decoded = try PCKUtility.decoder().decode(PCKPatient.self, from: encoded)
         decoded.entityId = patient.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKPatient.swift
+++ b/Sources/ParseCareKit/Objects/PCKPatient.swift
@@ -66,7 +66,7 @@ public struct PCKPatient: PCKVersionable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     /// A list of substances this patient is allergic to.
     public var allergies: [String]?

--- a/Sources/ParseCareKit/Objects/PCKPatient.swift
+++ b/Sources/ParseCareKit/Objects/PCKPatient.swift
@@ -304,7 +304,11 @@ public struct PCKPatient: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(patient)
         var decoded = try PCKUtility.decoder().decode(PCKPatient.self, from: encoded)
         decoded.entityId = patient.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = patient.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKTask.swift
@@ -75,7 +75,7 @@ public struct PCKTask: PCKVersionable {
 
     public var updatedAt: Date?
 
-    public var ACL: ParseACL? = try? ParseACL.defaultACL()
+    public var ACL: ParseACL?
 
     /// If true, completion of this task will be factored into the patient's overall adherence. True by default.
     public var impactsAdherence: Bool?

--- a/Sources/ParseCareKit/Objects/PCKTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKTask.swift
@@ -322,7 +322,11 @@ public struct PCKTask: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(task)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
-        decoded.ACL = PCKUtility.getDefaultACL()
+        if let acl = task.acl {
+            decoded.ACL = acl
+        } else {
+            decoded.ACL = PCKUtility.getDefaultACL()
+        }
         return decoded
     }
 

--- a/Sources/ParseCareKit/Objects/PCKTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKTask.swift
@@ -112,7 +112,9 @@ public struct PCKTask: PCKVersionable {
         case title, carePlan, carePlanUUID, impactsAdherence, instructions, schedule
     }
 
-    public init() { }
+    public init() {
+        ACL = PCKUtility.getDefaultACL()
+    }
 
     public func new(with careKitEntity: OCKEntity) throws -> PCKTask {
 
@@ -320,6 +322,7 @@ public struct PCKTask: PCKVersionable {
         let encoded = try PCKUtility.jsonEncoder().encode(task)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
         decoded.entityId = task.id
+        decoded.ACL = PCKUtility.getDefaultACL()
         return decoded
     }
 

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -52,26 +52,25 @@ public class PCKUtility {
             fatalError("Error in ParseCareKit.setupServer(). Couldn't serialize plist. \(error)")
         }
 
-        guard let parseDictionary = plistConfiguration["ParseClientConfiguration"] as? [String: AnyObject],
-            let appID = parseDictionary["ApplicationID"] as? String,
-            let server = parseDictionary["Server"] as? String,
+        guard let appID = plistConfiguration["ApplicationID"] as? String,
+            let server = plistConfiguration["Server"] as? String,
             let serverURL = URL(string: server) else {
                 fatalError("Error in ParseCareKit.setupServer(). Missing keys in \(plistConfiguration)")
         }
 
-        if let client = parseDictionary["ClientKey"] as? String {
+        if let client = plistConfiguration["ClientKey"] as? String {
             clientKey = client
         }
 
-        if let liveQuery = parseDictionary["LiveQueryServer"] as? String {
+        if let liveQuery = plistConfiguration["LiveQueryServer"] as? String {
             liveQueryURL = URL(string: liveQuery)
         }
 
-        if let internalTransactions = parseDictionary["UseTransactionsInternally"] as? Bool {
+        if let internalTransactions = plistConfiguration["UseTransactionsInternally"] as? Bool {
             useTransactionsInternally = internalTransactions
         }
 
-        if let deleteKeychain = parseDictionary["DeleteKeychainIfNeeded"] as? Bool {
+        if let deleteKeychain = plistConfiguration["DeleteKeychainIfNeeded"] as? Bool {
             deleteKeychainIfNeeded = deleteKeychain
         }
 
@@ -82,24 +81,6 @@ public class PCKUtility {
                               useTransactionsInternally: useTransactionsInternally,
                               deleteKeychainIfNeeded: deleteKeychainIfNeeded,
                               authentication: authentication)
-    }
-
-    /// Converts a date to a String.
-    public class func dateToString(_ date: Date) -> String {
-        let dateFormatter: DateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-        dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-
-        return dateFormatter.string(from: date)
-    }
-
-    /// Converts a String to a Date.
-    public class func stringToDate(_ date: String) -> Date? {
-        let dateFormatter: DateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-        dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-
-        return dateFormatter.date(from: date)
     }
 
     /// Get the current Parse Encoder with custom date strategy.

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -116,4 +116,13 @@ public class PCKUtility {
     public class func decoder() -> JSONDecoder {
         PCKOutcome.getDecoder()
     }
+
+    class func getDefaultACL() -> ParseACL? {
+        guard let aclString = UserDefaults.standard.value(forKey: ParseCareKitConstants.defaultACL) as? String,
+              let aclData = aclString.data(using: .utf8),
+              let acl = try? decoder().decode(ParseACL.self, from: aclData) else {
+                  return nil
+              }
+        return acl
+    }
 }

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -13,17 +13,22 @@ import os.log
 
 // swiftlint:disable line_length
 
-// #Mark - Custom Enums
-enum CustomKey {
-    static let customClass                                  = "customClass"
+public enum ParseCareKitConstants {
+    static let defaultACL = "edu.uky.cs.netreconlab.ParseCareKit_defaultACL"
 }
 
+// MARK: Coding
 enum PCKCodingKeys: String, CodingKey {
     case entityId, id
     case uuid, schemaVersion, createdDate, updatedDate, deletedDate, timezone,
          userInfo, groupIdentifier, tags, source, asset, remoteID, notes,
          logicalClock, className, ACL, objectId, updatedAt, createdAt
     case effectiveDate, previousVersionUUIDs, nextVersionUUIDs
+}
+
+// MARK: Custom Enums
+enum CustomKey {
+    static let customClass                                  = "customClass"
 }
 
 /// Types of ParseCareKit classes.
@@ -165,7 +170,7 @@ public enum PCKStoreClass: String {
     }
 }
 
-// #Mark - Parse Database Keys
+// MARK: Parse Database Keys
 
 /// Parse business logic keys. These keys can be used for querying Parse objects.
 public enum ParseKey {
@@ -221,7 +226,7 @@ public enum VersionableKey {
     public static let previousVersionUUIDs                        = "previousVersionUUIDs"
 }
 
-// #Mark - Patient Class
+// MARK: Patient Class
 /// Keys for `PCKPatient` objects. These keys can be used for querying Parse objects.
 public enum PatientKey {
     /// className key.
@@ -236,7 +241,7 @@ public enum PatientKey {
     public static let name                                     = "name"
 }
 
-// #Mark - CarePlan Class
+// MARK: CarePlan Class
 /// Keys for `PCKCarePlan` objects. These keys can be used for querying Parse objects.
 public enum CarePlanKey {
     /// className key.
@@ -247,7 +252,7 @@ public enum CarePlanKey {
     public static let title                                    = "title"
 }
 
-// #Mark - Contact Class
+// MARK: Contact Class
 /// Keys for `PCKContact` objects. These keys can be used for querying Parse objects.
 public enum ContactKey {
     /// className key.
@@ -276,7 +281,7 @@ public enum ContactKey {
     public static let otherContactInfo                         = "otherContactInfo"
 }
 
-// #Mark - Task Class
+// MARK: Task Class
 /// Keys for `PCKTask` objects. These keys can be used for querying Parse objects.
 public enum TaskKey {
     /// className key.
@@ -293,7 +298,7 @@ public enum TaskKey {
     public static let elements                                 = "elements"
 }
 
-// #Mark - Outcome Class
+// MARK: Outcome Class
 /// Keys for `PCKOutcome` objects. These keys can be used for querying Parse objects.
 public enum OutcomeKey {
     /// className key.
@@ -308,13 +313,13 @@ public enum OutcomeKey {
     public static let values                                   = "values"
 }
 
-// #Mark - Clock Class
+// MARK: Clock Class
 /// Keys for `Clock` objects. These keys can be used for querying Parse objects.
 public enum ClockKey {
     /// className key.
     public static let className                                = "Clock"
     /// uuid key.
     public static let uuid                                     = "uuid"
-    /// vectorKey key.
-    public static let vectorKey                                = "vector"
+    /// vector key.
+    public static let vector                                   = "vector"
 }

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -15,6 +15,7 @@ import os.log
 
 public enum ParseCareKitConstants {
     static let defaultACL = "edu.uky.cs.netreconlab.ParseCareKit_defaultACL"
+    static let acl = "_acl"
 }
 
 // MARK: Coding

--- a/Sources/ParseCareKit/ParseCareKitError.swift
+++ b/Sources/ParseCareKit/ParseCareKitError.swift
@@ -21,6 +21,7 @@ enum ParseCareKitError: Error {
     case cloudVersionNewerThanLocal
     case uuidAlreadyExists
     case cantCastToNeededClassType
+    case cantEncodeACL
     case classTypeNotAnEligibleType
     case couldntCreateConcreteClasses
     case syncAlreadyInProgress
@@ -57,6 +58,9 @@ extension ParseCareKitError: LocalizedError {
         case .cantCastToNeededClassType:
             return NSLocalizedString("Can't cast to needed class type",
                                      comment: "Can't cast to needed class type")
+        case .cantEncodeACL:
+            return NSLocalizedString("Can't encode ACL",
+                                     comment: "Can't encode ACL")
         case .classTypeNotAnEligibleType:
             return NSLocalizedString("PCKClass type isn't an eligible type",
                                      comment: "PCKClass type isn't an eligible type")

--- a/Sources/ParseCareKit/ParseCareKitLog.swift
+++ b/Sources/ParseCareKit/ParseCareKitLog.swift
@@ -23,6 +23,7 @@ extension OSLog {
     static let pullRevisions = OSLog(subsystem: subsystem, category: "\(category).pullRevisions")
     static let pushRevisions = OSLog(subsystem: subsystem, category: "\(category).pushRevisions")
     static let clock = OSLog(subsystem: subsystem, category: "\(category).clock")
+    static let initializer = OSLog(subsystem: subsystem, category: "\(category).initializer")
 }
 
 @available(iOS 14.0, watchOS 7.0, *)
@@ -40,4 +41,5 @@ extension Logger {
     static let pullRevisions = Logger(subsystem: subsystem, category: "\(category).pullRevisions")
     static let pushRevisions = Logger(subsystem: subsystem, category: "\(category).pushRevisions")
     static let clock = Logger(subsystem: subsystem, category: "\(category).clock")
+    static let initializer = Logger(subsystem: subsystem, category: "\(category).initializer")
 }

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -68,6 +68,24 @@ public class ParseRemote: OCKRemoteSynchronizable {
         self.automaticallySynchronizes = auto
         self.subscribeToServerUpdates = subscribeToServerUpdates
         if PCKUser.current != nil {
+            if (try? ParseACL.defaultACL()) == nil {
+                var defaultACL = ParseACL()
+                defaultACL.publicRead = false
+                defaultACL.publicWrite = false
+                do {
+                    _ = try ParseACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
+                } catch {
+                    if #available(iOS 14.0, watchOS 7.0, *) {
+                        Logger.initializer.error("\(error.localizedDescription)")
+                    } else {
+                        os_log("%{private}@.",
+                               log: .initializer,
+                               type: .error,
+                               error.localizedDescription)
+                    }
+
+                }
+            }
             subscribeToClock()
         }
     }

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -98,7 +98,10 @@ public class ParseRemote: OCKRemoteSynchronizable {
                             replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable],
                             subscribeToServerUpdates: Bool,
                             defaultACL: ParseACL? = nil) throws {
-        try self.init(uuid: uuid, auto: auto, subscribeToServerUpdates: subscribeToServerUpdates)
+        try self.init(uuid: uuid,
+                      auto: auto,
+                      subscribeToServerUpdates: subscribeToServerUpdates,
+                      defaultACL: defaultACL)
         try self.pckStoreClassesToSynchronize = PCKStoreClass
             .patient.replaceRemoteConcreteClasses(replacePCKStoreClasses)
         self.customClassesToSynchronize = nil
@@ -126,7 +129,10 @@ public class ParseRemote: OCKRemoteSynchronizable {
                             customClasses: [String: PCKSynchronizable],
                             subscribeToServerUpdates: Bool,
                             defaultACL: ParseACL? = nil) throws {
-        try self.init(uuid: uuid, auto: auto, subscribeToServerUpdates: subscribeToServerUpdates)
+        try self.init(uuid: uuid,
+                      auto: auto,
+                      subscribeToServerUpdates: subscribeToServerUpdates,
+                      defaultACL: defaultACL)
         if replacePCKStoreClasses != nil {
             self.pckStoreClassesToSynchronize = try PCKStoreClass
                 .patient.replaceRemoteConcreteClasses(replacePCKStoreClasses!)

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -57,35 +57,24 @@ public class ParseRemote: OCKRemoteSynchronizable {
         - uuid: The unique identifier of the remote clock.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
         - subscribeToServerUpdates: Automatically receive updates from other devices linked to this Clock.
-     Requires `ParseLiveQuery` server to be setup.
+        Requires `ParseLiveQuery` server to be setup.
+        - defaultACL: The default access control list for which users can access or modify `ParseCareKit`
+        objects. If no `defaultACL` is provided, the default is set to read/write for the user who created the data with
+        no public read/write access. This `defaultACL` is not the same as `ParseACL.defaultACL`. If you want the
+        the `ParseCareKit` `defaultACL` to match the `ParseACL.defaultACL`, you need to provide
+        `ParseACL.defaultACL`.
     */
     public init(uuid: UUID,
                 auto: Bool,
-                subscribeToServerUpdates: Bool) throws {
+                subscribeToServerUpdates: Bool,
+                defaultACL: ParseACL? = nil) throws {
         self.pckStoreClassesToSynchronize = try PCKStoreClass.patient.getConcrete()
         self.customClassesToSynchronize = nil
         self.uuid = uuid
         self.automaticallySynchronizes = auto
         self.subscribeToServerUpdates = subscribeToServerUpdates
-        if PCKUser.current != nil {
-            if (try? ParseACL.defaultACL()) == nil {
-                var defaultACL = ParseACL()
-                defaultACL.publicRead = false
-                defaultACL.publicWrite = false
-                do {
-                    _ = try ParseACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
-                } catch {
-                    if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.initializer.error("\(error.localizedDescription)")
-                    } else {
-                        os_log("%{private}@.",
-                               log: .initializer,
-                               type: .error,
-                               error.localizedDescription)
-                    }
-
-                }
-            }
+        if let currentUser = PCKUser.current {
+            Self.setDefaultACL(defaultACL, for: currentUser)
             subscribeToClock()
         }
     }
@@ -97,12 +86,18 @@ public class ParseRemote: OCKRemoteSynchronizable {
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
         - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized
         - subscribeToServerUpdates: Automatically receive updates from other devices linked to this Clock.
-     Requires `ParseLiveQuery` server to be setup.
+        Requires `ParseLiveQuery` server to be setup.
+        - defaultACL: The default access control list for which users can access or modify `ParseCareKit`
+        objects. If no `defaultACL` is provided, the default is set to read/write for the user who created the data with
+        no public read/write access. This `defaultACL` is not the same as `ParseACL.defaultACL`. If you want the
+        the `ParseCareKit` `defaultACL` to match the `ParseACL.defaultACL`, you need to provide
+        `ParseACL.defaultACL`.
     */
     convenience public init(uuid: UUID,
                             auto: Bool,
                             replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable],
-                            subscribeToServerUpdates: Bool) throws {
+                            subscribeToServerUpdates: Bool,
+                            defaultACL: ParseACL? = nil) throws {
         try self.init(uuid: uuid, auto: auto, subscribeToServerUpdates: subscribeToServerUpdates)
         try self.pckStoreClassesToSynchronize = PCKStoreClass
             .patient.replaceRemoteConcreteClasses(replacePCKStoreClasses)
@@ -118,13 +113,19 @@ public class ParseRemote: OCKRemoteSynchronizable {
             by passing in the respective Key/Value pairs. Defaults to nil, which uses the standard default entities.
         - customClasses: Add custom classes to synchroniz by passing in the respective Key/Value pair.
         - subscribeToServerUpdates: Automatically receive updates from other devices linked to this Clock.
-     Requires `ParseLiveQuery` server to be setup.
+        Requires `ParseLiveQuery` server to be setup.
+        - defaultACL: The default access control list for which users can access or modify `ParseCareKit`
+        objects. If no `defaultACL` is provided, the default is set to read/write for the user who created the data with
+        no public read/write access. This `defaultACL` is not the same as `ParseACL.defaultACL`. If you want the
+        the `ParseCareKit` `defaultACL` to match the `ParseACL.defaultACL`, you need to provide
+        `ParseACL.defaultACL`.
     */
     convenience public init(uuid: UUID,
                             auto: Bool,
                             replacePCKStoreClasses: [PCKStoreClass: PCKSynchronizable]? = nil,
                             customClasses: [String: PCKSynchronizable],
-                            subscribeToServerUpdates: Bool) throws {
+                            subscribeToServerUpdates: Bool,
+                            defaultACL: ParseACL? = nil) throws {
         try self.init(uuid: uuid, auto: auto, subscribeToServerUpdates: subscribeToServerUpdates)
         if replacePCKStoreClasses != nil {
             self.pckStoreClassesToSynchronize = try PCKStoreClass
@@ -133,6 +134,45 @@ public class ParseRemote: OCKRemoteSynchronizable {
             self.pckStoreClassesToSynchronize = nil
         }
         self.customClassesToSynchronize = customClasses
+    }
+
+    class func setDefaultACL(_ defaultACL: ParseACL?, for user: PCKUser) {
+        let acl: ParseACL!
+        if let defaultACL = defaultACL {
+            acl = defaultACL
+        } else {
+            var defaultACL = ParseACL()
+            defaultACL.publicRead = false
+            defaultACL.publicWrite = false
+            defaultACL.setReadAccess(user: user, value: true)
+            defaultACL.setWriteAccess(user: user, value: true)
+            acl = defaultACL
+        }
+        do {
+            let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
+            if let aclString = String(data: encodedACL, encoding: .utf8) {
+                UserDefaults.standard.setValue(aclString,
+                                               forKey: ParseCareKitConstants.defaultACL)
+                UserDefaults.standard.synchronize()
+            } else {
+                if #available(iOS 14.0, watchOS 7.0, *) {
+                    Logger.initializer.error("Couldn't encode defaultACL from user as string.")
+                } else {
+                    os_log("Couldn't encode defaultACL from user as string.",
+                           log: .initializer,
+                           type: .error)
+                }
+            }
+        } catch {
+            if #available(iOS 14.0, watchOS 7.0, *) {
+                Logger.initializer.error("Couldn't encode defaultACL from user. \(error.localizedDescription)")
+            } else {
+                os_log("Couldn't encode defaultACL from user. %{private}@.",
+                       log: .initializer,
+                       type: .error,
+                       error.localizedDescription)
+            }
+        }
     }
 
     func subscribeToClock() {

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -711,15 +711,16 @@ public class ParseRemote: OCKRemoteSynchronizable {
 
     public func chooseConflictResolution(conflicts: [OCKEntity], completion: @escaping OCKResultClosure<OCKEntity>) {
 
-        if let parseDelegate = self.parseDelegate {
-            parseDelegate
-                .chooseConflictResolution(conflicts: conflicts,
-                                          completion: completion)
-        } else {
-
-            /*
-            let conflictPolicy = OCKMergeConflictResolutionPolicy.keepRemote
-            completion(conflictPolicy)*/
+        guard let parseDelegate = self.parseDelegate else {
+            guard let first = conflicts.first else {
+                completion(.failure(.remoteSynchronizationFailed(reason: "Error: no conflict available")))
+                return
+            }
+            completion(.success(first))
+            return
         }
+        parseDelegate
+            .chooseConflictResolution(conflicts: conflicts,
+                                      completion: completion)
     }
 }

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -77,6 +77,24 @@ public protocol PCKObjectable: ParseObject {
     static func copyValues(from other: Self, to here: Self) throws -> Self
 }
 
+// MARK: Defaults
+extension PCKObjectable {
+    public var id: String {
+        guard let returnId = entityId else {
+            return ""
+        }
+        return returnId
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.uuid == rhs.uuid
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.uuid)
+    }
+}
+
 extension PCKObjectable {
 
     mutating func copyRelationalEntities(_ parse: Self) -> Self {
@@ -175,25 +193,7 @@ extension PCKObjectable {
     }
 }
 
-// Defaults
-extension PCKObjectable {
-    public var id: String {
-        guard let returnId = entityId else {
-            return ""
-        }
-        return returnId
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.uuid == rhs.uuid
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.uuid)
-    }
-}
-
-// Encodable
+// MARK: Encodable
 extension PCKObjectable {
 
     /**

--- a/Sources/ParseCareKit/Protocols/PCKVersionable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKVersionable.swift
@@ -229,7 +229,7 @@ extension PCKVersionable {
     }
 }
 
-// Fetching
+// MARK: Fetching
 extension PCKVersionable {
     private static func queryNotDeleted() -> Query<Self> {
         Self.query(doesNotExist(key: VersionableKey.deletedDate))
@@ -300,7 +300,7 @@ extension PCKVersionable {
     }
 }
 
-// Encodable
+// MARK: Encodable
 extension PCKVersionable {
 
     /**

--- a/TestHost/ParseCareKit.plist
+++ b/TestHost/ParseCareKit.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ApplicationID</key>
+	<string>3B5FD9DA-C278-4582-90DC-101C08E7FC98</string>
+	<key>ClientKey</key>
+	<string>hello</string>
+	<key>Server</key>
+	<string>http://localhost:1337/parse</string>
+	<key>LiveQueryServer</key>
+	<string>ws://localhost:1337/parse</string>
+	<key>UseTransactionsInternally</key>
+	<true/>
+	<key>DeleteKeychainIfNeeded</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -288,18 +288,31 @@ class ParseCareKitTests: XCTestCase {
     func testPatientACL() throws {
         var careKit = OCKPatient(id: "myId", givenName: "hello", familyName: "world")
         XCTAssertNil(careKit.acl)
+
         let user = try userLogin()
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+        // Should have default ACL
+        let parse = try PCKPatient.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -307,6 +320,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKPatient.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -454,14 +478,27 @@ class ParseCareKitTests: XCTestCase {
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+
+        // Should have default ACL
+        let parse = try PCKOutcome.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -469,6 +506,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKOutcome.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -616,14 +664,27 @@ class ParseCareKitTests: XCTestCase {
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+
+        // Should have default ACL
+        let parse = try PCKTask.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -631,6 +692,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKTask.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -784,14 +856,27 @@ class ParseCareKitTests: XCTestCase {
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+
+        // Should have default ACL
+        let parse = try PCKHealthKitTask.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -799,6 +884,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKHealthKitTask.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -931,14 +1027,27 @@ class ParseCareKitTests: XCTestCase {
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+
+        // Should have default ACL
+        let parse = try PCKCarePlan.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -946,6 +1055,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKCarePlan.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -1112,14 +1232,27 @@ class ParseCareKitTests: XCTestCase {
         parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
                                 auto: false,
                                 subscribeToServerUpdates: false)
+
+        // Should have default ACL
+        let parse = try PCKContact.copyCareKit(careKit)
+        guard let objectId = user.objectId,
+            let acl = parse.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl.publicRead, false)
+        XCTAssertEqual(acl.publicWrite, false)
+        XCTAssertTrue(acl.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl.getWriteAccess(objectId: objectId))
+
+        // Should have new ACL
         var newACL = ParseACL()
         newACL.publicRead = true
         newACL.publicWrite = true
         newACL.setReadAccess(user: user, value: true)
         newACL.setWriteAccess(user: user, value: true)
         try careKit.setACL(newACL)
-        guard let objectId = user.objectId,
-              let defaultACL = careKit.acl else {
+        guard let defaultACL = careKit.acl else {
             XCTFail("Should have objectId")
             return
         }
@@ -1127,6 +1260,17 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+
+        // ParseObject should have new ACL
+        let parse2 = try PCKContact.copyCareKit(careKit)
+        guard let acl2 = parse2.ACL else {
+            XCTFail("Should have ACL")
+            return
+        }
+        XCTAssertEqual(acl2.publicRead, true)
+        XCTAssertEqual(acl2.publicWrite, true)
+        XCTAssertTrue(acl2.getReadAccess(objectId: objectId))
+        XCTAssertTrue(acl2.getWriteAccess(objectId: objectId))
     }
 
 /*

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// swiftlint:disable type_body_length
+
 import XCTest
 @testable import ParseCareKit
 @testable import CareKitStore
@@ -72,7 +74,6 @@ func userLoginToRealServer() {
     }
 }
 
-// swiftlint:disable:next type_body_length
 class ParseCareKitTests: XCTestCase {
 
     private var parse: ParseRemote!
@@ -89,9 +90,10 @@ class ParseCareKitTests: XCTestCase {
                               serverURL: url,
                               testing: true)
         do {
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
+            _ = try userLogin()
+            parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                    auto: false,
+                                    subscribeToServerUpdates: false)
         } catch {
             print(error.localizedDescription)
         }
@@ -110,11 +112,8 @@ class ParseCareKitTests: XCTestCase {
     }
 
     func testSetDefaultACLLoggedIn() throws {
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+              let objectId = user.objectId,
               let defaultACL = PCKUtility.getDefaultACL() else {
             XCTFail("Should have objectId")
             return
@@ -133,10 +132,7 @@ class ParseCareKitTests: XCTestCase {
         userSetACL.setReadAccess(user: user, value: true)
         userSetACL.setWriteAccess(user: user, value: true)
 
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false,
-                                defaultACL: userSetACL)
+        ParseRemote.setDefaultACL(userSetACL, for: user)
         guard let objectId = user.objectId,
               let defaultACL = PCKUtility.getDefaultACL() else {
             XCTFail("Should have objectId")
@@ -146,10 +142,6 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(defaultACL.publicWrite, true)
         XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
         XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
-    }
-
-    func testDefaultACLNoLogin() throws {
-        XCTAssertNil(PCKUtility.getDefaultACL())
     }
 
     // swiftlint:disable:next function_body_length
@@ -289,13 +281,10 @@ class ParseCareKitTests: XCTestCase {
         var careKit = OCKPatient(id: "myId", givenName: "hello", familyName: "world")
         XCTAssertNil(careKit.acl)
 
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
         // Should have default ACL
         let parse = try PCKPatient.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return
@@ -474,14 +463,11 @@ class ParseCareKitTests: XCTestCase {
     func testOutcomeACL() throws {
         var careKit = OCKOutcome(taskUUID: UUID(), taskOccurrenceIndex: 0, values: [.init(10)])
         XCTAssertNil(careKit.acl)
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
 
         // Should have default ACL
         let parse = try PCKOutcome.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return
@@ -660,14 +646,11 @@ class ParseCareKitTests: XCTestCase {
         var careKit = OCKTask(id: "myId", title: "hello", carePlanUUID: UUID(),
                               schedule: .init(composing: [careKitSchedule]))
         XCTAssertNil(careKit.acl)
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
 
         // Should have default ACL
         let parse = try PCKTask.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return
@@ -852,14 +835,11 @@ class ParseCareKitTests: XCTestCase {
                                                                quantityType: .discrete,
                                                                unit: .degreeCelsius()))
         XCTAssertNil(careKit.acl)
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
 
         // Should have default ACL
         let parse = try PCKHealthKitTask.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return
@@ -1023,14 +1003,11 @@ class ParseCareKitTests: XCTestCase {
     func testCarePlanACL() throws {
         var careKit = OCKCarePlan(id: "myId", title: "hello", patientUUID: UUID())
         XCTAssertNil(careKit.acl)
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
 
         // Should have default ACL
         let parse = try PCKCarePlan.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return
@@ -1228,14 +1205,11 @@ class ParseCareKitTests: XCTestCase {
     func testContactACL() throws {
         var careKit = OCKContact(id: "myId", givenName: "hello", familyName: "world", carePlanUUID: UUID())
         XCTAssertNil(careKit.acl)
-        let user = try userLogin()
-        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
-                                auto: false,
-                                subscribeToServerUpdates: false)
 
         // Should have default ACL
         let parse = try PCKContact.copyCareKit(careKit)
-        guard let objectId = user.objectId,
+        guard let user = PCKUser.current,
+            let objectId = user.objectId,
             let acl = parse.ACL else {
             XCTFail("Should have ACL")
             return

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -285,6 +285,30 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
     }
 
+    func testPatientACL() throws {
+        var careKit = OCKPatient(id: "myId", givenName: "hello", familyName: "world")
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+    }
+
     // swiftlint:disable:next function_body_length
     func testOutcome() throws {
         var careKit = OCKOutcome(taskUUID: UUID(), taskOccurrenceIndex: 0, values: [.init(10)])
@@ -423,6 +447,30 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
     }
 
+    func testOutcomeACL() throws {
+        var careKit = OCKOutcome(taskUUID: UUID(), taskOccurrenceIndex: 0, values: [.init(10)])
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+    }
+
     // swiftlint:disable:next function_body_length
     func testTask() throws {
         let careKitSchedule = OCKScheduleElement(start: Date(),
@@ -556,6 +604,33 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUIDs, cloudDecoded.previousVersionUUIDs)
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
+    }
+
+    func testTaskACL() throws {
+        let careKitSchedule = OCKScheduleElement(start: Date(),
+                                                 end: Date().addingTimeInterval(3000), interval: .init(day: 1))
+        var careKit = OCKTask(id: "myId", title: "hello", carePlanUUID: UUID(),
+                              schedule: .init(composing: [careKitSchedule]))
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -696,6 +771,36 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
     }
 
+    func testHealthKitTaskACL() throws {
+        let careKitSchedule = OCKScheduleElement(start: Date(),
+                                                 end: Date().addingTimeInterval(3000), interval: .init(day: 1))
+        var careKit = OCKHealthKitTask(id: "myId", title: "hello", carePlanUUID: UUID(),
+                                       schedule: .init(composing: [careKitSchedule]),
+                                       healthKitLinkage: .init(quantityIdentifier: .bodyTemperature,
+                                                               quantityType: .discrete,
+                                                               unit: .degreeCelsius()))
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+    }
+
     // swiftlint:disable:next function_body_length
     func testCarePlan() throws {
         var careKit = OCKCarePlan(id: "myId", title: "hello", patientUUID: UUID())
@@ -817,6 +922,30 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertNotNil(cloudDecoded.effectiveDate)
         XCTAssertEqual(parse.previousVersionUUIDs, cloudDecoded.previousVersionUUIDs)
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
+    }
+
+    func testCarePlanACL() throws {
+        var careKit = OCKCarePlan(id: "myId", title: "hello", patientUUID: UUID())
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
     }
 
     // swiftlint:disable:next function_body_length
@@ -975,6 +1104,31 @@ class ParseCareKitTests: XCTestCase {
         XCTAssertEqual(parse.previousVersionUUIDs, cloudDecoded.previousVersionUUIDs)
         XCTAssertEqual(parse.nextVersionUUIDs, cloudDecoded.nextVersionUUIDs)
     }
+
+    func testContactACL() throws {
+        var careKit = OCKContact(id: "myId", givenName: "hello", familyName: "world", carePlanUUID: UUID())
+        XCTAssertNil(careKit.acl)
+        let user = try userLogin()
+        parse = try ParseRemote(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!,
+                                auto: false,
+                                subscribeToServerUpdates: false)
+        var newACL = ParseACL()
+        newACL.publicRead = true
+        newACL.publicWrite = true
+        newACL.setReadAccess(user: user, value: true)
+        newACL.setWriteAccess(user: user, value: true)
+        try careKit.setACL(newACL)
+        guard let objectId = user.objectId,
+              let defaultACL = careKit.acl else {
+            XCTFail("Should have objectId")
+            return
+        }
+        XCTAssertEqual(defaultACL.publicRead, true)
+        XCTAssertEqual(defaultACL.publicWrite, true)
+        XCTAssertTrue(defaultACL.getReadAccess(objectId: objectId))
+        XCTAssertTrue(defaultACL.getWriteAccess(objectId: objectId))
+    }
+
 /*
     func testAddContact() throws {
         let contact = OCKContact(id: "test", givenName: "hello", familyName: "world", carePlanUUID: nil)

--- a/Tests/ParseCareKitTests/LoggerTests.swift
+++ b/Tests/ParseCareKitTests/LoggerTests.swift
@@ -108,4 +108,13 @@ class LoggerTests: XCTestCase {
                    log: .clock, type: .error)
         }
     }
+
+    func testInitializer() throws {
+        if #available(iOS 14.0, watchOS 7.0, *) {
+            Logger.initializer.error("Testing")
+        } else {
+            os_log("Testing",
+                   log: .initializer, type: .error)
+        }
+    }
 }

--- a/Tests/ParseCareKitTests/UtilityTests.swift
+++ b/Tests/ParseCareKitTests/UtilityTests.swift
@@ -1,0 +1,37 @@
+//
+//  UtilityTests.swift
+//  ParseCareKitTests
+//
+//  Created by Corey Baker on 11/21/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import XCTest
+@testable import ParseCareKit
+@testable import ParseSwift
+
+class UtilityTests: XCTestCase {
+
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+        MockURLProtocol.removeAll()
+        try KeychainStore.shared.deleteAll()
+        try ParseStorage.shared.deleteAll()
+        UserDefaults.standard.removeObject(forKey: ParseCareKitConstants.defaultACL)
+        UserDefaults.standard.synchronize()
+    }
+
+    func testSetupServer() throws {
+        PCKUtility.setupServer { (_, completionHandler) in
+            completionHandler(.performDefaultHandling, nil)
+        }
+        XCTAssertEqual(ParseSwift.configuration.applicationId, "3B5FD9DA-C278-4582-90DC-101C08E7FC98")
+        XCTAssertEqual(ParseSwift.configuration.clientKey, "hello")
+        XCTAssertEqual(ParseSwift.configuration.serverURL, URL(string: "http://localhost:1337/parse"))
+        XCTAssertEqual(ParseSwift.configuration.liveQuerysServerURL, URL(string: "ws://localhost:1337/parse"))
+        XCTAssertTrue(ParseSwift.configuration.useTransactionsInternally)
+        XCTAssertTrue(ParseSwift.configuration.deleteKeychainIfNeeded)
+    }
+}


### PR DESCRIPTION
If the developer doesn't set a defaultACL for the objects being synced, create one for them.

- [x] Update to Parse-Swift 2.2.6
- [x] Allow a defaultACL to be set for ParseCareKit
- [x] Increase codecov 