### PR TITLE
Require Xcode 13.2+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 env:
   CI_XCODE_VER: '/Applications/Xcode_12.app/Contents/Developer'
-  CI_XCODE_13: '/Applications/Xcode_13.0.app/Contents/Developer'
+  CI_XCODE_13: '/Applications/Xcode_13.2.app/Contents/Developer'
   
 jobs:
   docs:

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "79b760f874c6e4c6c778734f5b85f591862530c1",
-          "version": "2.3.1"
+          "revision": "ccbbb33e82a73fab0a10abbc2b4994c45f662672",
+          "version": "2.4.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ParseCareKit",
-    platforms: [.iOS(.v15), .watchOS(.v8), .macOS(.v12), .tvOS(.v15)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(
             name: "ParseCareKit",
@@ -15,7 +15,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "CareKit", url: "https://github.com/carekit-apple/CareKit.git",
                  .revision("a612482e4ba4f28d4c75129c0a9b70ca23098bd6")),
-        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "2.3.1")
+        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "2.4.0")
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1140,7 +1140,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.3.1;
+				minimumVersion = 2.4.0;
 			};
 		};
 		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "79b760f874c6e4c6c778734f5b85f591862530c1",
-          "version": "2.3.1"
+          "revision": "ccbbb33e82a73fab0a10abbc2b4994c45f662672",
+          "version": "2.4.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ParseCareKit
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FParseCareKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/netreconlab/ParseCareKit)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FParseCareKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/netreconlab/ParseCareKit)
-![Xcode 13.0+](https://img.shields.io/badge/xcode-13.0%2B-blue.svg)
+![Xcode 13.2+](https://img.shields.io/badge/xcode-13.2%2B-blue.svg)
 [![CI Status](https://github.com/netreconlab/ParseCareKit/workflows/ci/badge.svg?branch=main)](https://github.com/netreconlab/ParseCareKit/actions?query=workflow%3Aci)
 [![Release Status](https://github.com/netreconlab/ParseCareKit/workflows/release/badge.svg)](https://github.com/netreconlab/ParseCareKit/actions?query=workflow%3Arelease)
 [![Slider Status](https://github.com/netreconlab/ParseCareKit/workflows/slider/badge.svg)](https://github.com/netreconlab/ParseCareKit/actions?query=workflow%3Aslider)

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -36,7 +36,7 @@ public class PCKUtility {
         var plistConfiguration: [String: AnyObject]
         var clientKey: String?
         var liveQueryURL: URL?
-        var useTransactionsInternally = false
+        var useTransactions = false
         var deleteKeychainIfNeeded = false
         guard let path = Bundle.main.path(forResource: "ParseCareKit", ofType: "plist"),
             let xml = FileManager.default.contents(atPath: path) else {
@@ -66,8 +66,8 @@ public class PCKUtility {
             liveQueryURL = URL(string: liveQuery)
         }
 
-        if let internalTransactions = plistConfiguration["UseTransactionsInternally"] as? Bool {
-            useTransactionsInternally = internalTransactions
+        if let transactions = plistConfiguration["UseTransactions"] as? Bool {
+            useTransactions = transactions
         }
 
         if let deleteKeychain = plistConfiguration["DeleteKeychainIfNeeded"] as? Bool {
@@ -78,7 +78,7 @@ public class PCKUtility {
                               clientKey: clientKey,
                               serverURL: serverURL,
                               liveQueryServerURL: liveQueryURL,
-                              useTransactionsInternally: useTransactionsInternally,
+                              useTransactions: useTransactions,
                               deleteKeychainIfNeeded: deleteKeychainIfNeeded,
                               authentication: authentication)
     }

--- a/TestHost/ParseCareKit.plist
+++ b/TestHost/ParseCareKit.plist
@@ -10,7 +10,7 @@
 	<string>http://localhost:1337/parse</string>
 	<key>LiveQueryServer</key>
 	<string>ws://localhost:1337/parse</string>
-	<key>UseTransactionsInternally</key>
+	<key>UseTransactions</key>
 	<true/>
 	<key>DeleteKeychainIfNeeded</key>
 	<true/>

--- a/Tests/ParseCareKitTests/UtilityTests.swift
+++ b/Tests/ParseCareKitTests/UtilityTests.swift
@@ -31,7 +31,7 @@ class UtilityTests: XCTestCase {
         XCTAssertEqual(ParseSwift.configuration.clientKey, "hello")
         XCTAssertEqual(ParseSwift.configuration.serverURL, URL(string: "http://localhost:1337/parse"))
         XCTAssertEqual(ParseSwift.configuration.liveQuerysServerURL, URL(string: "ws://localhost:1337/parse"))
-        XCTAssertTrue(ParseSwift.configuration.useTransactionsInternally)
+        XCTAssertTrue(ParseSwift.configuration.useTransactions)
         XCTAssertTrue(ParseSwift.configuration.deleteKeychainIfNeeded)
     }
 }


### PR DESCRIPTION
- Xcode 13.2 is backwards compatible with `.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)`
- Minimum ParseSwift version is 2.4.0