### PR TITLE
Remove saving uuid on ParseCareKit objects

### DIFF
--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1140,7 +1140,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 2.5.0;
 			};
 		};
 		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParseCareKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": null,
-          "revision": "369cf2aa5f0fe60b0ea712605b929ccbfba4ef4d",
-          "version": "2.4.0"
+          "revision": "ebaaf12b21f73ceda047928d4401b34b118d4e72",
+          "version": "2.5.0"
         }
       }
     ]

--- a/Sources/ParseCareKit/Objects/PCKCarePlan.swift
+++ b/Sources/ParseCareKit/Objects/PCKCarePlan.swift
@@ -23,8 +23,6 @@ public struct PCKCarePlan: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public var uuid: UUID?
-
     public var entityId: String?
 
     public var logicalClock: Int?
@@ -96,7 +94,7 @@ public struct PCKCarePlan: PCKVersionable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate,
+        case entityId, schemaVersion, createdDate, updatedDate, deletedDate,
              timezone, userInfo, groupIdentifier, tags, source, asset, remoteID,
              notes, logicalClock
         case previousVersionUUIDs, nextVersionUUIDs, effectiveDate
@@ -123,37 +121,7 @@ public struct PCKCarePlan: PCKVersionable {
     }
 
     public func addToCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-
-        let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemote.queue) { result in
-
-            switch result {
-
-            case .success(let foundEntity):
-                guard foundEntity.entityId == self.entityId else {
-                    // This object has a duplicate uuid but isn't the same object
-                    completion(.failure(ParseCareKitError.uuidAlreadyExists))
-                    return
-                }
-                completion(.success(foundEntity))
-
-            case .failure(let error):
-
-                switch error.code {
-                case .internalServer, .objectNotFound:
-                    // 1 - this column hasn't been added. 101 - Query returned no results
-                    self.save(completion: completion)
-                default:
-                    // There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.carePlan.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
-                    } else {
-                        os_log("addToCloud(), %{private}@", log: .carePlan, type: .error, error.localizedDescription)
-                    }
-                    completion(.failure(error))
-                }
-            }
-        }
+        self.save(completion: completion)
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
@@ -166,7 +134,7 @@ public struct PCKCarePlan: PCKVersionable {
         previousVersionUUIDs.append(uuid)
 
         // Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Self.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
+        let query = Self.query(containedIn(key: ParseKey.objectId, array: previousVersionUUIDs))
             .includeAll()
         query.find(callbackQueue: ParseRemote.queue) { results in
 
@@ -309,6 +277,7 @@ public struct PCKCarePlan: PCKVersionable {
         }
         let encoded = try PCKUtility.jsonEncoder().encode(carePlan)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
+        decoded.objectId = carePlan.uuid.uuidString
         decoded.entityId = carePlan.id
         if let acl = carePlan.acl {
             decoded.ACL = acl

--- a/Sources/ParseCareKit/Objects/PCKClock.swift
+++ b/Sources/ParseCareKit/Objects/PCKClock.swift
@@ -25,7 +25,13 @@ struct PCKClock: ParseObjectMutable {
 
     var ACL: ParseACL?
 
-    var uuid: UUID?
+    var uuid: UUID? {
+        guard let objectId = objectId,
+            let uuid = UUID(uuidString: objectId) else {
+            return nil
+        }
+        return uuid
+    }
 
     var vector: String?
 
@@ -80,7 +86,7 @@ struct PCKClock: ParseObjectMutable {
                                                     ParseError?) -> Void) {
 
         // Fetch Clock from Cloud
-        let query = Self.query(ClockKey.uuid == uuid)
+        let query = Self.query(ParseKey.objectId == uuid)
         query.first(callbackQueue: ParseRemote.queue) { result in
 
             switch result {
@@ -106,8 +112,8 @@ struct PCKClock: ParseObjectMutable {
 
 extension PCKClock {
     init(uuid: UUID) {
-        self.uuid = uuid
-        vector = "{\"processes\":[{\"id\":\"\(self.uuid!.uuidString)\",\"clock\":0}]}"
+        self.objectId = uuid.uuidString
+        vector = "{\"processes\":[{\"id\":\"\(uuid.uuidString)\",\"clock\":0}]}"
         ACL = PCKUtility.getDefaultACL()
     }
 }

--- a/Sources/ParseCareKit/Objects/PCKContact.swift
+++ b/Sources/ParseCareKit/Objects/PCKContact.swift
@@ -27,8 +27,6 @@ public struct PCKContact: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public var uuid: UUID?
-
     public var entityId: String?
 
     public var logicalClock: Int?
@@ -125,7 +123,7 @@ public struct PCKContact: PCKVersionable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate,
+        case entityId, schemaVersion, createdDate, updatedDate, deletedDate,
              timezone, userInfo, groupIdentifier, tags, source, asset, remoteID,
              notes, logicalClock
         case previousVersionUUIDs, nextVersionUUIDs, effectiveDate
@@ -154,37 +152,7 @@ public struct PCKContact: PCKVersionable {
     }
 
     public func addToCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-
-        // Check to see if already in the cloud
-        let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemote.queue) { result in
-
-            switch result {
-
-            case .success(let foundEntity):
-                guard foundEntity.entityId == self.entityId else {
-                    // This object has a duplicate uuid but isn't the same object
-                    completion(.failure(ParseCareKitError.uuidAlreadyExists))
-                    return
-                }
-                completion(.success(foundEntity))
-
-            case .failure(let error):
-                switch error.code {
-                // 1 - this column hasn't been added. 101 - Query returned no results
-                case .internalServer, .objectNotFound:
-                        self.save(completion: completion)
-                default:
-                    // There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.contact.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
-                    } else {
-                        os_log("addToCloud(), %{private}@", log: .contact, type: .error, error.localizedDescription)
-                    }
-                    completion(.failure( error))
-                }
-            }
-        }
+        self.save(completion: completion)
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
@@ -196,7 +164,7 @@ public struct PCKContact: PCKVersionable {
         previousVersionUUIDs.append(uuid)
 
         // Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Self.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
+        let query = Self.query(containedIn(key: ParseKey.objectId, array: previousVersionUUIDs))
             .includeAll()
         query.find(callbackQueue: ParseRemote.queue) { results in
 
@@ -345,6 +313,7 @@ public struct PCKContact: PCKVersionable {
         }
         let encoded = try PCKUtility.jsonEncoder().encode(contact)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
+        decoded.objectId = contact.uuid.uuidString
         decoded.entityId = contact.id
         if let acl = contact.acl {
             decoded.ACL = acl

--- a/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
+++ b/Sources/ParseCareKit/Objects/PCKHealthKitTask.swift
@@ -29,8 +29,6 @@ public struct PCKHealthKitTask: PCKVersionable {
 
     public var effectiveDate: Date?
 
-    public var uuid: UUID?
-
     public var entityId: String?
 
     public var logicalClock: Int?
@@ -110,7 +108,9 @@ public struct PCKHealthKitTask: PCKVersionable {
 
     enum CodingKeys: String, CodingKey {
         case objectId, createdAt, updatedAt
-        case uuid, entityId, schemaVersion, createdDate, updatedDate, deletedDate, timezone, userInfo, groupIdentifier, tags, source, asset, remoteID, notes, logicalClock
+        case entityId, schemaVersion, createdDate, updatedDate,
+             deletedDate, timezone, userInfo, groupIdentifier,
+             tags, source, asset, remoteID, notes, logicalClock
         case previousVersionUUIDs, nextVersionUUIDs, effectiveDate
         case title, carePlan, carePlanUUID, impactsAdherence, instructions, schedule, healthKitLinkage
     }
@@ -135,38 +135,7 @@ public struct PCKHealthKitTask: PCKVersionable {
     }
 
     public func addToCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
-
-        // Check to see if already in the cloud
-        let query = Self.query(ObjectableKey.uuid == uuid)
-        query.first(callbackQueue: ParseRemote.queue) { result in
-
-            switch result {
-
-            case .success(let foundEntity):
-                guard foundEntity.entityId == self.entityId else {
-                    // This object has a duplicate uuid but isn't the same object
-                    completion(.failure(ParseCareKitError.uuidAlreadyExists))
-                    return
-                }
-                completion(.success(foundEntity))
-
-            case .failure(let error):
-                switch error.code {
-                case .internalServer, .objectNotFound:
-                    // 1 - this column hasn't been added. 101 - Query returned no results
-                    self.save(completion: completion)
-                default:
-                    // There was a different issue that we don't know how to handle
-                    if #available(iOS 14.0, watchOS 7.0, *) {
-                        Logger.healthKitTask.error("addToCloud(), \(error.localizedDescription, privacy: .private)")
-                    } else {
-                        os_log("addToCloud(), %{private}@", log: .healthKitTask, type: .error, error.localizedDescription)
-                    }
-                    completion(.failure(error))
-                }
-                return
-            }
-        }
+        self.save(completion: completion)
     }
 
     public func updateCloud(completion: @escaping(Result<PCKSynchronizable, Error>) -> Void) {
@@ -178,7 +147,7 @@ public struct PCKHealthKitTask: PCKVersionable {
         previousVersionUUIDs.append(uuid)
 
         // Check to see if this entity is already in the Cloud, but not matched locally
-        let query = Self.query(containedIn(key: ObjectableKey.uuid, array: previousVersionUUIDs))
+        let query = Self.query(containedIn(key: ParseKey.objectId, array: previousVersionUUIDs))
             .includeAll()
         query.find(callbackQueue: ParseRemote.queue) { results in
 
@@ -324,6 +293,7 @@ public struct PCKHealthKitTask: PCKVersionable {
 
         let encoded = try PCKUtility.jsonEncoder().encode(task)
         var decoded = try PCKUtility.decoder().decode(Self.self, from: encoded)
+        decoded.objectId = task.uuid.uuidString
         decoded.entityId = task.id
         if let acl = task.acl {
             decoded.ACL = acl

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -78,6 +78,7 @@ public class PCKUtility {
                               clientKey: clientKey,
                               serverURL: serverURL,
                               liveQueryServerURL: liveQueryURL,
+                              allowCustomObjectId: true,
                               useTransactions: useTransactions,
                               deleteKeychainIfNeeded: deleteKeychainIfNeeded,
                               authentication: authentication)

--- a/Sources/ParseCareKit/ParseCareKitConstants.swift
+++ b/Sources/ParseCareKit/ParseCareKitConstants.swift
@@ -187,8 +187,6 @@ public enum ParseKey {
 
 /// Keys for all `PCKObjectable` objects. These keys can be used for querying Parse objects.
 public enum ObjectableKey {
-    /// objectId key.
-    public static let uuid                                       = "uuid"
     /// entityId key.
     public static let entityId                                   = "entityId"
     /// asset key.
@@ -319,8 +317,6 @@ public enum OutcomeKey {
 public enum ClockKey {
     /// className key.
     public static let className                                = "Clock"
-    /// uuid key.
-    public static let uuid                                     = "uuid"
     /// vector key.
     public static let vector                                   = "vector"
 }

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -190,7 +190,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
                 return
             }
 
-            let clockQuery = PCKClock.query(ClockKey.uuid == self.uuid)
+            let clockQuery = PCKClock.query(ParseKey.objectId == self.uuid)
             guard let subscription = clockQuery.subscribeCallback else {
                 if #available(iOS 14.0, watchOS 7.0, *) {
                     Logger.clock.error("Couldn't subscribe to clock query")

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -16,62 +16,62 @@ import os.log
 */
 public protocol PCKObjectable: ParseObject {
     /// A universally unique identifier for this object.
-    var uuid: UUID? { get set }
+    var uuid: UUID? { get }
 
     /// A human readable unique identifier. It is used strictly by the developer and will never be shown to a user
     var id: String { get }
 
     /// A human readable unique identifier (same as `id`, but this is what's on the Parse server, `id` is
     /// already taken in Parse). It is used strictly by the developer and will never be shown to a user
-    var entityId: String? {get set}
+    var entityId: String? { get set }
 
     // The clock value of when this object was added to the Parse server.
-    var logicalClock: Int? {get set}
+    var logicalClock: Int? { get set }
 
     /// The semantic version of the database schema when this object was created.
     /// The value will be nil for objects that have not yet been persisted.
-    var schemaVersion: OCKSemanticVersion? {get set}
+    var schemaVersion: OCKSemanticVersion? { get set }
 
     /// The date at which the object was first persisted to the database.
     /// It will be nil for unpersisted values and objects.
-    var createdDate: Date? {get set}
+    var createdDate: Date? { get set }
 
     /// The last date at which the object was updated.
     /// It will be nil for unpersisted values and objects.
-    var updatedDate: Date? {get set}
+    var updatedDate: Date? { get set }
 
     /// The timezone this record was created in.
-    var timezone: TimeZone? {get set}
+    var timezone: TimeZone? { get set }
 
     /// A dictionary of information that can be provided by developers to support their own unique
     /// use cases.
-    var userInfo: [String: String]? {get set}
+    var userInfo: [String: String]? { get set }
 
     /// A user-defined group identifier that can be used both for querying and sorting results.
     /// Examples may include: "medications", "exercises", "family", "males", "diabetics", etc.
-    var groupIdentifier: String? {get set}
+    var groupIdentifier: String? { get set }
 
     /// An array of user-defined tags that can be used to sort or classify objects or values.
-    var tags: [String]? {get set}
+    var tags: [String]? { get set }
 
     /// Specifies where this object originated from. It could contain information about the device
     /// used to record the data, its software version, or the person who recorded the data.
-    var source: String? {get set}
+    var source: String? { get set }
 
     /// Specifies the location of some asset associated with this object. It could be the URL for
     /// an image or video, the bundle name of a audio asset, or any other representation the
     /// developer chooses.
-    var asset: String? {get set}
+    var asset: String? { get set }
 
     /// Any array of notes associated with this object.
-    var notes: [OCKNote]? {get set}
+    var notes: [OCKNote]? { get set }
 
     /// A unique id optionally used by a remote database. Its precise format will be
     /// determined by the remote database, but it is generally not expected to be human readable.
-    var remoteID: String? {get set}
+    var remoteID: String? { get set }
 
     /// A boolean that is `true` when encoding the object for Parse. If `false` the object is encoding for CareKit.
-    var encodingForParse: Bool {get set}
+    var encodingForParse: Bool { get set }
 
     /// Copy the values of a ParseCareKit object
     static func copyValues(from other: Self, to here: Self) throws -> Self
@@ -79,6 +79,14 @@ public protocol PCKObjectable: ParseObject {
 
 // MARK: Defaults
 extension PCKObjectable {
+    public var uuid: UUID? {
+        guard let objectId = objectId,
+            let uuid = UUID(uuidString: objectId) else {
+            return nil
+        }
+        return uuid
+    }
+
     public var id: String {
         guard let returnId = entityId else {
             return ""
@@ -106,7 +114,6 @@ extension PCKObjectable {
     /// Copies the common values of another PCKObjectable object.
     /// - parameter from: The PCKObjectable object to copy from.
     mutating public func copyCommonValues(from other: Self) {
-        uuid = other.uuid
         entityId = other.entityId
         updatedDate = other.updatedDate
         timezone = other.timezone
@@ -163,7 +170,7 @@ extension PCKObjectable {
                 return
         }
 
-        let query = Self.query(ObjectableKey.uuid == uuidString)
+        let query = Self.query(ParseKey.objectId == uuidString)
             .includeAll()
         query.first(options: options,
                     callbackQueue: ParseRemote.queue) { result in
@@ -208,14 +215,15 @@ extension PCKObjectable {
             if !(self is PCKOutcome) {
                 try container.encodeIfPresent(entityId, forKey: .entityId)
             }
+            try container.encodeIfPresent(objectId, forKey: .objectId)
             try container.encodeIfPresent(ACL, forKey: .ACL)
             try container.encodeIfPresent(logicalClock, forKey: .logicalClock)
         } else {
             if !(self is PCKOutcome) {
                 try container.encodeIfPresent(entityId, forKey: .id)
             }
+            try container.encodeIfPresent(uuid, forKey: .uuid)
         }
-        try container.encodeIfPresent(uuid, forKey: .uuid)
         try container.encodeIfPresent(schemaVersion, forKey: .schemaVersion)
         try container.encodeIfPresent(createdDate, forKey: .createdDate)
         try container.encodeIfPresent(updatedDate, forKey: .updatedDate)

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -88,6 +88,7 @@ class ParseCareKitTests: XCTestCase {
                               clientKey: "clientKey",
                               masterKey: "masterKey",
                               serverURL: url,
+                              allowCustomObjectId: true,
                               testing: true)
         do {
             _ = try userLogin()
@@ -246,11 +247,13 @@ class ParseCareKitTests: XCTestCase {
             return
         }
         parse.notes = [note]
-        let cloudEncoded = try ParseCoding.parseEncoder().encode(parse)
+        let cloudEncoded = try ParseCoding.parseEncoder().encode(parse,
+                                                                 skipKeys: .customObjectId)
         let cloudDecoded = try ParseCoding.jsonDecoder().decode(PCKPatient.self, from: cloudEncoded)
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)
@@ -435,6 +438,7 @@ class ParseCareKitTests: XCTestCase {
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)
@@ -615,6 +619,7 @@ class ParseCareKitTests: XCTestCase {
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)
@@ -801,6 +806,7 @@ class ParseCareKitTests: XCTestCase {
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)
@@ -976,6 +982,7 @@ class ParseCareKitTests: XCTestCase {
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)
@@ -1171,6 +1178,7 @@ class ParseCareKitTests: XCTestCase {
 
         // Objectable
         XCTAssertEqual(parse.className, cloudDecoded.className)
+        XCTAssertEqual(parse.objectId, cloudDecoded.objectId)
         XCTAssertEqual(parse.uuid, cloudDecoded.uuid)
         XCTAssertEqual(parse.entityId, cloudDecoded.entityId)
         XCTAssertNotNil(cloudDecoded.createdDate)


### PR DESCRIPTION
- [x] The `uuid` of all ParseCareKit objects is now `objectId`
- [x] allowCustomObjectId has been abled on the client

**Warning** these updates are not backwards compatible with previous versions of parse-hipaa or ParseCareKit.