### PR TITLE
fix: Properly setACL if userInfo already set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
 env:
-  CI_XCODE_13: '/Applications/Xcode_13.2.app/Contents/Developer'
+  CI_XCODE_13: '/Applications/Xcode_13.2.1.app/Contents/Developer'
 
 jobs:
   xcode-test-ios:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 env:
   CI_XCODE_VER: '/Applications/Xcode_12.app/Contents/Developer'
-  CI_XCODE_13: '/Applications/Xcode_13.2.app/Contents/Developer'
+  CI_XCODE_13: '/Applications/Xcode_13.2.1.app/Contents/Developer'
   
 jobs:
   docs:

--- a/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKCarePlan+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKCarePlan {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKContact+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKContact {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKHealthKitTask+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKHealthKitTask {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKOutcome+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKOutcome {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKPatient+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKPatient {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKTask+Parse.swift
@@ -30,8 +30,8 @@ public extension OCKTask {
                 guard let aclString = String(data: encodedACL, encoding: .utf8) else {
                     throw ParseCareKitError.cantEncodeACL
                 }
-                if var userInfo = userInfo {
-                    userInfo[ParseCareKitConstants.acl] = aclString
+                if userInfo != nil {
+                    userInfo?[ParseCareKitConstants.acl] = aclString
                 } else {
                     userInfo = [ParseCareKitConstants.acl: aclString]
                 }

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -154,6 +154,11 @@ public class ParseRemote: OCKRemoteSynchronizable {
             defaultACL.setWriteAccess(user: user, value: true)
             acl = defaultACL
         }
+        if let currentDefaultACL = PCKUtility.getDefaultACL() {
+            if acl == currentDefaultACL {
+                return
+            }
+        }
         do {
             let encodedACL = try PCKUtility.jsonEncoder().encode(acl)
             if let aclString = String(data: encodedACL, encoding: .utf8) {


### PR DESCRIPTION
When an OCKEntity already has `userInfo` set, an update to the ACL currently doesn't mutable the entity. 