### PR TITLE
upgrade to ParseSwift 4.9.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
+        "repositoryURL": "https://github.com/cbaker6/CareKit.git",
         "state": {
           "branch": null,
-          "revision": "a612482e4ba4f28d4c75129c0a9b70ca23098bd6",
+          "revision": "adca4ac261b265e4fb7ded5a88e14deaed39592c",
           "version": null
         }
       },
@@ -23,8 +23,8 @@
         "package": "ParseSwift",
         "repositoryURL": "https://github.com/cbaker6/Parse-Swift.git",
         "state": {
-          "branch": "syncKeychain",
-          "revision": "1a0d2352413328ae751f180228b3b5a58f43ecd4",
+          "branch": null,
+          "revision": "4a374a4c84092ea01aed091de38bef4645743251",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
+        "repositoryURL": "https://github.com/cbaker6/Parse-Swift.git",
         "state": {
-          "branch": null,
-          "revision": "ca93e3accce539a484f8d0f4382e3a3e5bc9f0e5",
-          "version": "4.3.1"
+          "branch": "syncKeychain",
+          "revision": "1a0d2352413328ae751f180228b3b5a58f43ecd4",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "46494967d2636e388b34b88b023aa4c3bb86b945")
+                 revision: "4a374a4c84092ea01aed091de38bef4645743251")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "8feb0fac0bf64f3fe4cdeba3d7ea1db84fd740b2")
+                 revision: "4507f8bf3b26a358931c2efc2827d948aefdce22")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "b038b34a2c9bacfe99c764a5a2b717b0c22d0593")
+                 revision: "1a9a53f548291d6d0866ba91496d20f19da7e98a")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
             targets: ["ParseCareKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/carekit-apple/CareKit.git",
-                 revision: "a612482e4ba4f28d4c75129c0a9b70ca23098bd6"),
+        .package(url: "https://github.com/cbaker6/CareKit.git",
+                 revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
                  revision: "1a0d2352413328ae751f180228b3b5a58f43ecd4")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "e0563bf29ee87c728d909445a9561d257e1930b6")
+                 revision: "d492f93c1ffebb0dbec51bb161925fed9b1e809c")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "64b64d44c7242d06f7228d00a878a9569fd5041e")
+                 revision: "8feb0fac0bf64f3fe4cdeba3d7ea1db84fd740b2")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
-        .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "b53023421204d850cbb63f5918b49a90b42c582c")
-        // .package(url: "https://github.com/parse-community/Parse-Swift.git",
-        //          .upToNextMajor(from: "4.9.0"))
+         .package(url: "https://github.com/parse-community/Parse-Swift.git",
+                  .upToNextMajor(from: "4.9.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "d492f93c1ffebb0dbec51bb161925fed9b1e809c")
+                 revision: "64b64d44c7242d06f7228d00a878a9569fd5041e")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "4a374a4c84092ea01aed091de38bef4645743251")
+                 revision: "b038b34a2c9bacfe99c764a5a2b717b0c22d0593")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "1a0d2352413328ae751f180228b3b5a58f43ecd4")
+                 revision: "46494967d2636e388b34b88b023aa4c3bb86b945")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "1a9a53f548291d6d0866ba91496d20f19da7e98a")
+                 revision: "e0563bf29ee87c728d909445a9561d257e1930b6")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
         .package(url: "https://github.com/cbaker6/Parse-Swift.git",
-                 revision: "4507f8bf3b26a358931c2efc2827d948aefdce22")
+                 revision: "b53023421204d850cbb63f5918b49a90b42c582c")
         // .package(url: "https://github.com/parse-community/Parse-Swift.git",
         //          .upToNextMajor(from: "4.9.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/carekit-apple/CareKit.git",
                  revision: "a612482e4ba4f28d4c75129c0a9b70ca23098bd6"),
-        .package(url: "https://github.com/parse-community/Parse-Swift.git",
-                 .upToNextMajor(from: "4.3.1"))
+        .package(url: "https://github.com/cbaker6/Parse-Swift.git",
+                 revision: "1a0d2352413328ae751f180228b3b5a58f43ecd4")
+        // .package(url: "https://github.com/parse-community/Parse-Swift.git",
+        //          .upToNextMajor(from: "4.9.0"))
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -43,10 +43,10 @@
 		70B5578727A7439B002C39D4 /* PCKReadRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578527A7439B002C39D4 /* PCKReadRole.swift */; };
 		70B5578927A744A9002C39D4 /* PCKWriteRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578827A744A9002C39D4 /* PCKWriteRole.swift */; };
 		70B5578A27A744A9002C39D4 /* PCKWriteRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578827A744A9002C39D4 /* PCKWriteRole.swift */; };
-		70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD4261286270056DE0C /* CareKitStore */; };
-		70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD826128D9D0056DE0C /* CareKitStore */; };
 		70D41D7328B44CF600613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7228B44CF600613510 /* ParseSwift */; };
 		70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7428B44D0A00613510 /* ParseSwift */; };
+		70D41D7C28B453B500613510 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7B28B453B500613510 /* CareKitStore */; };
+		70D41D7E28B453C600613510 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7D28B453C600613510 /* CareKitStore */; };
 		70D5A29425E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
@@ -218,8 +218,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D7E28B453C600613510 /* CareKitStore in Frameworks */,
 				70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */,
-				70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,8 +227,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D7C28B453B500613510 /* CareKitStore in Frameworks */,
 				70D41D7328B44CF600613510 /* ParseSwift in Frameworks */,
-				70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,8 +498,8 @@
 			);
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
-				70C0AFD826128D9D0056DE0C /* CareKitStore */,
 				70D41D7428B44D0A00613510 /* ParseSwift */,
+				70D41D7D28B453C600613510 /* CareKitStore */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -522,8 +522,8 @@
 			);
 			name = ParseCareKit;
 			packageProductDependencies = (
-				70C0AFD4261286270056DE0C /* CareKitStore */,
 				70D41D7228B44CF600613510 /* ParseSwift */,
+				70D41D7B28B453B500613510 /* CareKitStore */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -565,8 +565,8 @@
 			);
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
-				70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */,
 				70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
+				70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1153,14 +1153,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
-			requirement = {
-				kind = revision;
-				revision = a612482e4ba4f28d4c75129c0a9b70ca23098bd6;
-			};
-		};
 		70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cbaker6/Parse-Swift.git";
@@ -1169,19 +1161,17 @@
 				kind = branch;
 			};
 		};
+		70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/cbaker6/CareKit.git";
+			requirement = {
+				kind = revision;
+				revision = adca4ac261b265e4fb7ded5a88e14deaed39592c;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		70C0AFD4261286270056DE0C /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
-		};
-		70C0AFD826128D9D0056DE0C /* CareKitStore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
-			productName = CareKitStore;
-		};
 		70D41D7228B44CF600613510 /* ParseSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
@@ -1191,6 +1181,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
 			productName = ParseSwift;
+		};
+		70D41D7B28B453B500613510 /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
+		};
+		70D41D7D28B453C600613510 /* CareKitStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */;
+			productName = CareKitStore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -43,10 +43,10 @@
 		70B5578727A7439B002C39D4 /* PCKReadRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578527A7439B002C39D4 /* PCKReadRole.swift */; };
 		70B5578927A744A9002C39D4 /* PCKWriteRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578827A744A9002C39D4 /* PCKWriteRole.swift */; };
 		70B5578A27A744A9002C39D4 /* PCKWriteRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578827A744A9002C39D4 /* PCKWriteRole.swift */; };
-		70D41D7328B44CF600613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7228B44CF600613510 /* ParseSwift */; };
-		70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7428B44D0A00613510 /* ParseSwift */; };
 		70D41D7C28B453B500613510 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7B28B453B500613510 /* CareKitStore */; };
 		70D41D7E28B453C600613510 /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7D28B453C600613510 /* CareKitStore */; };
+		70D41D8628B7EA7B00613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D8528B7EA7B00613510 /* ParseSwift */; };
+		70D41D8828B7EA8D00613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D8728B7EA8D00613510 /* ParseSwift */; };
 		70D5A29425E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
@@ -218,8 +218,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D8828B7EA8D00613510 /* ParseSwift in Frameworks */,
 				70D41D7E28B453C600613510 /* CareKitStore in Frameworks */,
-				70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,8 +227,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D8628B7EA7B00613510 /* ParseSwift in Frameworks */,
 				70D41D7C28B453B500613510 /* CareKitStore in Frameworks */,
-				70D41D7328B44CF600613510 /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,8 +498,8 @@
 			);
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
-				70D41D7428B44D0A00613510 /* ParseSwift */,
 				70D41D7D28B453C600613510 /* CareKitStore */,
+				70D41D8728B7EA8D00613510 /* ParseSwift */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -522,8 +522,8 @@
 			);
 			name = ParseCareKit;
 			packageProductDependencies = (
-				70D41D7228B44CF600613510 /* ParseSwift */,
 				70D41D7B28B453B500613510 /* CareKitStore */,
+				70D41D8528B7EA7B00613510 /* ParseSwift */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -565,8 +565,8 @@
 			);
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
-				70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
 				70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */,
+				70D41D8428B7EA7B00613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1153,14 +1153,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/cbaker6/Parse-Swift.git";
-			requirement = {
-				branch = syncKeychain;
-				kind = branch;
-			};
-		};
 		70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/cbaker6/CareKit.git";
@@ -1169,19 +1161,17 @@
 				revision = adca4ac261b265e4fb7ded5a88e14deaed39592c;
 			};
 		};
+		70D41D8428B7EA7B00613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/parse-community/Parse-Swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		70D41D7228B44CF600613510 /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
-		};
-		70D41D7428B44D0A00613510 /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
-		};
 		70D41D7B28B453B500613510 /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */;
@@ -1191,6 +1181,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 70D41D7A28B453B500613510 /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
+		};
+		70D41D8528B7EA7B00613510 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D8428B7EA7B00613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
+		};
+		70D41D8728B7EA8D00613510 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D8428B7EA7B00613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -20,8 +20,6 @@
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
 		705DC92D2526A5650035BBE3 /* MockURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7772524E92900DDF53D /* MockURLResponse.swift */; };
-		7075542D255D899E00172F6B /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7075542C255D899E00172F6B /* ParseSwift */; };
-		70755431255D89B800172F6B /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70755430255D89B800172F6B /* ParseSwift */; };
 		7085DDAD26CDA2980033B977 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 7085DDAC26CDA2980033B977 /* Documentation.docc */; };
 		709752E3250D27300020EA70 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709752E2250D27300020EA70 /* AppDelegate.swift */; };
 		709752E5250D27300020EA70 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709752E4250D27300020EA70 /* SceneDelegate.swift */; };
@@ -47,6 +45,8 @@
 		70B5578A27A744A9002C39D4 /* PCKWriteRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B5578827A744A9002C39D4 /* PCKWriteRole.swift */; };
 		70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD4261286270056DE0C /* CareKitStore */; };
 		70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */ = {isa = PBXBuildFile; productRef = 70C0AFD826128D9D0056DE0C /* CareKitStore */; };
+		70D41D7328B44CF600613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7228B44CF600613510 /* ParseSwift */; };
+		70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70D41D7428B44D0A00613510 /* ParseSwift */; };
 		70D5A29425E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70D5A29525E0D2D30036A8AD /* PCKHealthKitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A29325E0D2D30036A8AD /* PCKHealthKitTask.swift */; };
 		70F2E181254EFC8000B2EA5C /* PCKObjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918F07ED247D66C800C3A205 /* PCKObjectable.swift */; };
@@ -218,8 +218,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D7528B44D0A00613510 /* ParseSwift in Frameworks */,
 				70C0AFD926128D9D0056DE0C /* CareKitStore in Frameworks */,
-				70755431255D89B800172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,8 +227,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70D41D7328B44CF600613510 /* ParseSwift in Frameworks */,
 				70C0AFD5261286270056DE0C /* CareKitStore in Frameworks */,
-				7075542D255D899E00172F6B /* ParseSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,8 +498,8 @@
 			);
 			name = "ParseCareKit-watchOS";
 			packageProductDependencies = (
-				70755430255D89B800172F6B /* ParseSwift */,
 				70C0AFD826128D9D0056DE0C /* CareKitStore */,
+				70D41D7428B44D0A00613510 /* ParseSwift */,
 			);
 			productName = "ParseCareKit-watchOS";
 			productReference = 70F2E177254EFC6100B2EA5C /* ParseCareKit_watchOS.framework */;
@@ -522,8 +522,8 @@
 			);
 			name = ParseCareKit;
 			packageProductDependencies = (
-				7075542C255D899E00172F6B /* ParseSwift */,
 				70C0AFD4261286270056DE0C /* CareKitStore */,
+				70D41D7228B44CF600613510 /* ParseSwift */,
 			);
 			productName = ParseCareKit;
 			productReference = 9119D5EB245618D7001B7AA3 /* ParseCareKit.framework */;
@@ -565,8 +565,8 @@
 			);
 			mainGroup = 9119D5E1245618D7001B7AA3;
 			packageReferences = (
-				7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */,
 				70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */,
+				70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */,
 			);
 			productRefGroup = 9119D5EC245618D7001B7AA3 /* Products */;
 			projectDirPath = "";
@@ -1153,14 +1153,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/parse-community/Parse-Swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.3.1;
-			};
-		};
 		70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/carekit-apple/CareKit.git";
@@ -1169,19 +1161,17 @@
 				revision = a612482e4ba4f28d4c75129c0a9b70ca23098bd6;
 			};
 		};
+		70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/cbaker6/Parse-Swift.git";
+			requirement = {
+				branch = syncKeychain;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7075542C255D899E00172F6B /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
-		};
-		70755430255D89B800172F6B /* ParseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7075542B255D899E00172F6B /* XCRemoteSwiftPackageReference "Parse-Swift" */;
-			productName = ParseSwift;
-		};
 		70C0AFD4261286270056DE0C /* CareKitStore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
@@ -1191,6 +1181,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 70C0AFD3261286270056DE0C /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKitStore;
+		};
+		70D41D7228B44CF600613510 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
+		};
+		70D41D7428B44D0A00613510 /* ParseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 70D41D7128B44CF600613510 /* XCRemoteSwiftPackageReference "Parse-Swift" */;
+			productName = ParseSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -82,6 +82,7 @@ public class PCKUtility {
                               liveQueryServerURL: liveQueryURL,
                               allowingCustomObjectIds: true,
                               usingTransactions: useTransactions,
+                              usingPostForQuery: true,
                               deletingKeychainIfNeeded: deleteKeychainIfNeeded,
                               authentication: authentication)
     }

--- a/Sources/ParseCareKit/PCKUtility.swift
+++ b/Sources/ParseCareKit/PCKUtility.swift
@@ -37,8 +37,6 @@ public class PCKUtility {
      - LiveQueryServer - (String) The live query server URL to connect to Parse Server.
      - UseTransactionsInternally - (Boolean) Use transactions inside the Client SDK.
      - DeleteKeychainIfNeeded - (Boolean) Deletes the Parse Keychain when the app is running for the first time.
-     - AccessGroup - (String) The Keychain access group.
-     - SynchronizeKeychain - (Boolean) Whether or not to synchronize the Keychain across devices.
      - parameter fileName: Name of **.plist** file that contains config. Defaults to "ParseCareKit".
      - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
      Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
@@ -55,8 +53,6 @@ public class PCKUtility {
         var liveQueryURL: URL?
         var useTransactions = false
         var deleteKeychainIfNeeded = false
-        var accessGroup: String?
-        var synchronizeKeychain = false
         do {
             plistConfiguration = try Self.getPlistConfiguration(fileName: fileName)
         } catch {
@@ -85,14 +81,6 @@ public class PCKUtility {
             deleteKeychainIfNeeded = deleteKeychain
         }
 
-        if let keychainAccessGroup = plistConfiguration["AccessGroup"] as? String {
-            accessGroup = keychainAccessGroup
-        }
-
-        if let synchronizeKeychainAcrossDevices = plistConfiguration["SynchronizeKeychain"] as? Bool {
-            synchronizeKeychain = synchronizeKeychainAcrossDevices
-        }
-
         ParseSwift.initialize(applicationId: appID,
                               clientKey: clientKey,
                               serverURL: serverURL,
@@ -100,8 +88,6 @@ public class PCKUtility {
                               allowingCustomObjectIds: true,
                               usingTransactions: useTransactions,
                               usingPostForQuery: true,
-                              accessGroup: accessGroup,
-                              syncingKeychainAcrossDevices: synchronizeKeychain,
                               deletingKeychainIfNeeded: deleteKeychainIfNeeded,
                               authentication: authentication)
     }

--- a/Tests/ParseCareKitTests/EncodingCareKitTests.swift
+++ b/Tests/ParseCareKitTests/EncodingCareKitTests.swift
@@ -90,6 +90,7 @@ class ParseCareKitTests: XCTestCase {
                               masterKey: "masterKey",
                               serverURL: url,
                               allowingCustomObjectIds: true,
+                              usingPostForQuery: true,
                               testing: true)
         do {
             _ = try userLogin()


### PR DESCRIPTION
Upgrade to ParseSwift 4.9.0.

- Add `setAccessGroup` method to SDK which allows developers to set the Keychain access group and cloud synchronization of Keychain via a plist file. The new options added to the plist file are `AccessGroup: String`, `SynchronizeKeychain: Bool` 