### PR TITLE
set min ParseSwift to 4.9.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "ParseSwift",
-        "repositoryURL": "https://github.com/cbaker6/Parse-Swift.git",
+        "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "4a374a4c84092ea01aed091de38bef4645743251",
-          "version": null
+          "revision": "15d1724e84d4ee8f819bc5a1efc7efa0427db3e3",
+          "version": "4.9.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
          .package(url: "https://github.com/parse-community/Parse-Swift.git",
-                  .upToNextMajor(from: "4.9.0"))
+                  .upToNextMajor(from: "4.9.1"))
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1166,7 +1166,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.9.0;
+				minimumVersion = 4.9.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Set minimum ParseSwift to 4.9.1 to fix memory leak and run on Xcode 14