### PR TITLE
Minimum support Parse-Swift 4.14.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": null,
-          "revision": "085f5ad30d26c43251d82a3d0f412bfb9be3b473",
-          "version": "4.14.0"
+          "revision": "40a7b42b20c22253d53b09dc49c37fbb7973fdfe",
+          "version": "4.14.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
                  revision: "adca4ac261b265e4fb7ded5a88e14deaed39592c"),
          .package(url: "https://github.com/parse-community/Parse-Swift.git",
-                  .upToNextMajor(from: "4.14.0"))
+                  .upToNextMajor(from: "4.14.1"))
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -1167,7 +1167,7 @@
 			repositoryURL = "https://github.com/parse-community/Parse-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.14.0;
+				minimumVersion = 4.14.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
- [x] Min support for Parse-Swift SDK is now 4.14.1. Should provide more efficient network communication and no thread warnings from ParseCareKit in Xcode