### PR TITLE
fix: Improve conformance to Hashable and Equatable

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/Parse-Swift.git",
       "state" : {
-        "revision" : "10ec67c29050cc7e9d69bc59dda787ec5a145e75",
-        "version" : "5.10.0"
+        "revision" : "f13ad6b7ecee396e6fecb2685d3e171823ff6c3d",
+        "version" : "5.10.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/cbaker6/CareKit.git",
             .upToNextMajor(from: "3.0.0-beta.14")),
         .package(url: "https://github.com/netreconlab/Parse-Swift.git",
-            .upToNextMajor(from: "5.10.0"))
+            .upToNextMajor(from: "5.10.3"))
     ],
     targets: [
         .target(

--- a/ParseCareKit.xcodeproj/project.pbxproj
+++ b/ParseCareKit.xcodeproj/project.pbxproj
@@ -17,6 +17,15 @@
 		705DC9292526A55E0035BBE3 /* EncodingCareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7782524E92900DDF53D /* EncodingCareKitTests.swift */; };
 		705DC92B2526A5610035BBE3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7762524E92900DDF53D /* MockURLProtocol.swift */; };
 		705DC92D2526A5650035BBE3 /* MockURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7098A7772524E92900DDF53D /* MockURLResponse.swift */; };
+		707DC1D22C4345B100FC1DFD /* OCKSemanticVersion+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1D12C4345B100FC1DFD /* OCKSemanticVersion+Parse.swift */; };
+		707DC1D42C4346D000FC1DFD /* OCKNote+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1D32C4346D000FC1DFD /* OCKNote+Parse.swift */; };
+		707DC1D62C4347B000FC1DFD /* OCKSchedule+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1D52C4347B000FC1DFD /* OCKSchedule+Parse.swift */; };
+		707DC1D82C43486900FC1DFD /* OCKScheduleElement+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1D72C43486900FC1DFD /* OCKScheduleElement+Parse.swift */; };
+		707DC1DA2C43492300FC1DFD /* OCKOutcomeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1D92C43492300FC1DFD /* OCKOutcomeValue.swift */; };
+		707DC1DC2C434B1E00FC1DFD /* OCKBiologicalSex+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1DB2C434B1E00FC1DFD /* OCKBiologicalSex+Parse.swift */; };
+		707DC1DE2C434B8700FC1DFD /* OCKPostalAddress+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1DD2C434B8700FC1DFD /* OCKPostalAddress+Parse.swift */; };
+		707DC1E02C434BD700FC1DFD /* OCKContactCategory+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1DF2C434BD700FC1DFD /* OCKContactCategory+Parse.swift */; };
+		707DC1E22C434C1A00FC1DFD /* OCKLabeledValue+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707DC1E12C434C1A00FC1DFD /* OCKLabeledValue+Parse.swift */; };
 		7085DDAD26CDA2980033B977 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 7085DDAC26CDA2980033B977 /* Documentation.docc */; };
 		708A2CA42A092EE100AAB18A /* TestHostAllApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708A2CA32A092EE100AAB18A /* TestHostAllApp.swift */; };
 		708A2CA62A092EE100AAB18A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708A2CA52A092EE100AAB18A /* ContentView.swift */; };
@@ -119,6 +128,15 @@
 		700B0EDB270DE0C400EEF103 /* PCKVersionable+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PCKVersionable+combine.swift"; sourceTree = "<group>"; };
 		70365BEA2A0D774400F577F7 /* ParseCareKit.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ParseCareKit.xctestplan; sourceTree = "<group>"; };
 		705DC91D2526A4B80035BBE3 /* ParseCareKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParseCareKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		707DC1D12C4345B100FC1DFD /* OCKSemanticVersion+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKSemanticVersion+Parse.swift"; sourceTree = "<group>"; };
+		707DC1D32C4346D000FC1DFD /* OCKNote+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKNote+Parse.swift"; sourceTree = "<group>"; };
+		707DC1D52C4347B000FC1DFD /* OCKSchedule+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKSchedule+Parse.swift"; sourceTree = "<group>"; };
+		707DC1D72C43486900FC1DFD /* OCKScheduleElement+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKScheduleElement+Parse.swift"; sourceTree = "<group>"; };
+		707DC1D92C43492300FC1DFD /* OCKOutcomeValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKOutcomeValue.swift; sourceTree = "<group>"; };
+		707DC1DB2C434B1E00FC1DFD /* OCKBiologicalSex+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKBiologicalSex+Parse.swift"; sourceTree = "<group>"; };
+		707DC1DD2C434B8700FC1DFD /* OCKPostalAddress+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKPostalAddress+Parse.swift"; sourceTree = "<group>"; };
+		707DC1DF2C434BD700FC1DFD /* OCKContactCategory+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKContactCategory+Parse.swift"; sourceTree = "<group>"; };
+		707DC1E12C434C1A00FC1DFD /* OCKLabeledValue+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKLabeledValue+Parse.swift"; sourceTree = "<group>"; };
 		7085DDAC26CDA2980033B977 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		708A2CA12A092EE100AAB18A /* TestHostAll.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHostAll.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		708A2CA32A092EE100AAB18A /* TestHostAllApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHostAllApp.swift; sourceTree = "<group>"; };
@@ -329,11 +347,20 @@
 		91226D50274ABFCF00B5C2DF /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				707DC1DB2C434B1E00FC1DFD /* OCKBiologicalSex+Parse.swift */,
 				91226D53274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift */,
 				91226D55274AC1EF00B5C2DF /* OCKContact+Parse.swift */,
+				707DC1DF2C434BD700FC1DFD /* OCKContactCategory+Parse.swift */,
 				91226D57274AC20A00B5C2DF /* OCKHealthKitTask+Parse.swift */,
+				707DC1E12C434C1A00FC1DFD /* OCKLabeledValue+Parse.swift */,
+				707DC1D32C4346D000FC1DFD /* OCKNote+Parse.swift */,
 				91226D59274AC23300B5C2DF /* OCKOutcome+Parse.swift */,
+				707DC1D92C43492300FC1DFD /* OCKOutcomeValue.swift */,
 				91226D51274AC00500B5C2DF /* OCKPatient+Parse.swift */,
+				707DC1DD2C434B8700FC1DFD /* OCKPostalAddress+Parse.swift */,
+				707DC1D52C4347B000FC1DFD /* OCKSchedule+Parse.swift */,
+				707DC1D72C43486900FC1DFD /* OCKScheduleElement+Parse.swift */,
+				707DC1D12C4345B100FC1DFD /* OCKSemanticVersion+Parse.swift */,
 				91226D5B274AC24A00B5C2DF /* OCKTask+Parse.swift */,
 			);
 			path = Extensions;
@@ -579,10 +606,13 @@
 			files = (
 				709D175D258551D20002E772 /* ParseCareKitLog.swift in Sources */,
 				700B0ED3270DD62200EEF103 /* PCKObjectable+async.swift in Sources */,
+				707DC1DC2C434B1E00FC1DFD /* OCKBiologicalSex+Parse.swift in Sources */,
 				700B0ED6270DD7D900EEF103 /* PCKVersionable+async.swift in Sources */,
 				9119D60B24561B02001B7AA3 /* ParseCareKitConstants.swift in Sources */,
 				700B0ED9270DDF5600EEF103 /* PCKObjectable+combine.swift in Sources */,
 				9181F1A629EC48B700C50391 /* PCKEntity.swift in Sources */,
+				707DC1E02C434BD700FC1DFD /* OCKContactCategory+Parse.swift in Sources */,
+				707DC1DA2C43492300FC1DFD /* OCKOutcomeValue.swift in Sources */,
 				91226D5A274AC23300B5C2DF /* OCKOutcome+Parse.swift in Sources */,
 				9119D60D24561B22001B7AA3 /* PCKUtility.swift in Sources */,
 				700775AA2522686D00EC0EDA /* PCKVersionable.swift in Sources */,
@@ -603,13 +633,19 @@
 				7099D21C29ED8B420037CD8E /* PCKStoreClass.swift in Sources */,
 				91226D52274AC00500B5C2DF /* OCKPatient+Parse.swift in Sources */,
 				70B5578927A744A9002C39D4 /* PCKWriteRole.swift in Sources */,
+				707DC1D22C4345B100FC1DFD /* OCKSemanticVersion+Parse.swift in Sources */,
+				707DC1DE2C434B8700FC1DFD /* OCKPostalAddress+Parse.swift in Sources */,
 				7085DDAD26CDA2980033B977 /* Documentation.docc in Sources */,
 				91226D56274AC1EF00B5C2DF /* OCKContact+Parse.swift in Sources */,
 				9181F1A329EC47D800C50391 /* PCKRevisionRecord.swift in Sources */,
 				91226D54274AC1DB00B5C2DF /* OCKCarePlan+Parse.swift in Sources */,
 				709D1818258699840002E772 /* ParseRemoteDelegate.swift in Sources */,
 				70B5578327A74113002C39D4 /* PCKRoleable.swift in Sources */,
+				707DC1D82C43486900FC1DFD /* OCKScheduleElement+Parse.swift in Sources */,
 				916570D72462DABC008F2997 /* ParseRemote.swift in Sources */,
+				707DC1E22C434C1A00FC1DFD /* OCKLabeledValue+Parse.swift in Sources */,
+				707DC1D62C4347B000FC1DFD /* OCKSchedule+Parse.swift in Sources */,
+				707DC1D42C4346D000FC1DFD /* OCKNote+Parse.swift in Sources */,
 				70B5578627A7439B002C39D4 /* PCKReadRole.swift in Sources */,
 				9119D60724561A28001B7AA3 /* PCKCarePlan.swift in Sources */,
 			);
@@ -1012,7 +1048,7 @@
 			repositoryURL = "https://github.com/netreconlab/Parse-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.10.0;
+				minimumVersion = 5.10.3;
 			};
 		};
 		91FF60492AC0A51100E90E16 /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/Sources/ParseCareKit/Extensions/OCKBiologicalSex+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKBiologicalSex+Parse.swift
@@ -1,0 +1,20 @@
+//
+//  OCKBiologicalSex+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKBiologicalSex: @unchecked Sendable {}
+
+extension OCKBiologicalSex: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKContactCategory+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKContactCategory+Parse.swift
@@ -1,0 +1,12 @@
+//
+//  OCKContactCategory+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKContactCategory: @unchecked Sendable {}

--- a/Sources/ParseCareKit/Extensions/OCKLabeledValue+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKLabeledValue+Parse.swift
@@ -1,0 +1,21 @@
+//
+//  OCKLabeledValue+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKLabeledValue: @unchecked Sendable {}
+
+extension OCKLabeledValue: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(label)
+        hasher.combine(value)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKNote+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKNote+Parse.swift
@@ -1,0 +1,22 @@
+//
+//  OCKNote+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKNote: @unchecked Sendable {}
+
+extension OCKNote: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(author)
+        hasher.combine(title)
+        hasher.combine(content)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKOutcomeValue.swift
+++ b/Sources/ParseCareKit/Extensions/OCKOutcomeValue.swift
@@ -1,0 +1,28 @@
+//
+//  OCKOutcomeValue.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKOutcomeValue: @unchecked Sendable {}
+
+extension OCKOutcomeValue: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(units)
+        hasher.combine(createdDate)
+        hasher.combine(integerValue)
+        hasher.combine(doubleValue)
+        hasher.combine(booleanValue)
+        hasher.combine(stringValue)
+        hasher.combine(dataValue)
+        hasher.combine(dateValue)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKPostalAddress+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKPostalAddress+Parse.swift
@@ -1,0 +1,12 @@
+//
+//  OCKPostalAddress+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKPostalAddress: @unchecked Sendable {}

--- a/Sources/ParseCareKit/Extensions/OCKSchedule+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKSchedule+Parse.swift
@@ -1,0 +1,20 @@
+//
+//  OCKSchedule+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKSchedule: @unchecked Sendable {}
+
+extension OCKSchedule: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(elements)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKScheduleElement+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKScheduleElement+Parse.swift
@@ -1,0 +1,31 @@
+//
+//  OCKScheduleElement+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKScheduleElement: @unchecked Sendable {}
+
+extension OCKScheduleElement.Duration: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self)
+    }
+}
+
+extension OCKScheduleElement: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(text)
+        hasher.combine(duration)
+        hasher.combine(start)
+        hasher.combine(end)
+        hasher.combine(interval)
+        hasher.combine(targetValues)
+    }
+
+}

--- a/Sources/ParseCareKit/Extensions/OCKSemanticVersion+Parse.swift
+++ b/Sources/ParseCareKit/Extensions/OCKSemanticVersion+Parse.swift
@@ -1,0 +1,22 @@
+//
+//  OCKSemanticVersion+Parse.swift
+//  ParseCareKit
+//
+//  Created by Corey Baker on 7/13/24.
+//  Copyright © 2024 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+
+extension OCKSemanticVersion: @unchecked Sendable {}
+
+extension OCKSemanticVersion: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(majorVersion)
+        hasher.combine(minorVersion)
+        hasher.combine(patchNumber)
+    }
+
+}

--- a/Sources/ParseCareKit/Models/PCKEntity.swift
+++ b/Sources/ParseCareKit/Models/PCKEntity.swift
@@ -10,7 +10,7 @@ import CareKitStore
 import Foundation
 
 /// Holds one of several possible modified entities.
-public enum PCKEntity: Equatable, Codable {
+public enum PCKEntity: Hashable, Codable, Sendable {
 
     /// A patient entity.
     case patient(PCKPatient)

--- a/Sources/ParseCareKit/Models/PCKRevisionRecord.swift
+++ b/Sources/ParseCareKit/Models/PCKRevisionRecord.swift
@@ -12,7 +12,7 @@ import ParseSwift
 
 /// Revision records are exchanged by the CareKit and a ParseCareKit remote during synchronization.
 /// Each revision record contains an array of entities as well as a knowledge vector.
-struct PCKRevisionRecord: ParseObject, Equatable, Codable {
+struct PCKRevisionRecord: ParseObject {
 
     public static var className: String {
         "RevisionRecord"
@@ -116,10 +116,29 @@ struct PCKRevisionRecord: ParseObject, Equatable, Codable {
              logicalClock, clock, clockUUID
     }
 
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(createdAt)
+        hasher.combine(updatedAt)
+        hasher.combine(ACL)
+        hasher.combine(originalData)
+        hasher.combine(clockUUID)
+        hasher.combine(knowledgeVectorString)
+        hasher.combine(logicalClock)
+        hasher.combine(clock)
+        hasher.combine(entities)
+    }
+
     static func == (lhs: PCKRevisionRecord, rhs: PCKRevisionRecord) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.createdAt == rhs.createdAt &&
+        lhs.updatedAt == rhs.updatedAt &&
+        lhs.ACL == rhs.ACL &&
+        lhs.originalData == rhs.originalData &&
+        lhs.clockUUID == rhs.clockUUID &&
+        lhs.clock == rhs.clock &&
         lhs.knowledgeVectorString == rhs.knowledgeVectorString &&
         lhs.logicalClock == rhs.logicalClock &&
-        lhs.objectId == rhs.objectId &&
         lhs.entities == rhs.entities
     }
 

--- a/Sources/ParseCareKit/Models/PCKStoreClass.swift
+++ b/Sources/ParseCareKit/Models/PCKStoreClass.swift
@@ -13,7 +13,7 @@ import os.log
 // swiftlint:disable line_length
 
 /// Types of ParseCareKit classes.
-public enum PCKStoreClass: String, Equatable, CaseIterable {
+public enum PCKStoreClass: String, Hashable, CaseIterable, Sendable {
     /// The ParseCareKit equivalent of `OCKPatient`.
     case patient
     /// The ParseCareKit equivalent of `OCKCarePlan`.

--- a/Sources/ParseCareKit/Protocols/PCKObjectable.swift
+++ b/Sources/ParseCareKit/Protocols/PCKObjectable.swift
@@ -116,14 +116,6 @@ extension PCKObjectable {
         }
         return returnId
     }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.uuid == rhs.uuid
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.uuid)
-    }
 }
 
 extension PCKObjectable {


### PR DESCRIPTION
- [x] Update to ParseSwift 5.10.3 and improve conformance to `Hashable` and `Equatable`