### PR TITLE
fix: Attempt to push all entities even after transaction error

### DIFF
--- a/Sources/ParseCareKit/Models/PCKRevisionRecord.swift
+++ b/Sources/ParseCareKit/Models/PCKRevisionRecord.swift
@@ -8,6 +8,7 @@
 
 import CareKitStore
 import Foundation
+import os.log
 import ParseSwift
 
 /// Revision records are exchanged by the CareKit and a ParseCareKit remote during synchronization.
@@ -152,31 +153,226 @@ struct PCKRevisionRecord: ParseObject {
                                  knowledgeVector: knowledgeVector)
     }
 
-	func save(options: API.Options = [], batchLimit: Int) async throws {
-        try await patients.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
-        try await carePlans.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
-        try await contacts.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
-        try await tasks.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
-        try await healthKitTasks.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
-        try await outcomes.createAll(
-			batchLimit: batchLimit,
-			options: options
-		)
+	func save(
+		options: API.Options = [],
+		batchLimit: Int
+	) async throws {
+		let duplicateErrorString = "Attempted to add an object that is already on the server, skipping the save"
+		let patientObjectIDs: [String] = patients.compactMap(\.objectId)
+		do {
+			let numberOfPatients = patients.count
+			if numberOfPatients > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfPatients) Patients to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await patients.createAll(
+				batchLimit: numberOfPatients,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following Patients are already on the server: \(patientObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
+
+		let carePlanObjectIDs: [String] = carePlans.compactMap(\.objectId)
+		do {
+			let numberOfCarePlans = carePlans.count
+			if numberOfCarePlans > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfCarePlans) CarePlans to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await carePlans.createAll(
+				batchLimit: numberOfCarePlans,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following CarePlans are already on the server: \(carePlanObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
+
+		let contactObjectIDs: [String] = contacts.compactMap(\.objectId)
+		do {
+			let numberOfContacts = contacts.count
+			if numberOfContacts > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfContacts) Contacts to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await contacts.createAll(
+				batchLimit: numberOfContacts,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following Contacts are already on the server: \(contactObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
+
+		let taskObjectIDs: [String] = tasks.compactMap(\.objectId)
+		do {
+			let numberOfTasks = tasks.count
+			if numberOfTasks > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfTasks) Tasks to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await tasks.createAll(
+				batchLimit: numberOfTasks,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following Tasks are already on the server: \(taskObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
+
+		let healthKitTaskObjectIDs: [String] = healthKitTasks.compactMap(\.objectId)
+		do {
+			let numberOfHealthKitTasks = healthKitTasks.count
+			if numberOfHealthKitTasks > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfHealthKitTasks) HealthKitTasks to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await healthKitTasks.createAll(
+				batchLimit: numberOfHealthKitTasks,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following HealthKitTasks are already on the server: \(healthKitTaskObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
+
+		let outcomeObjectIDs: [String] = outcomes.compactMap(\.objectId)
+		do {
+			let numberOfOutcomes = outcomes.count
+			if numberOfOutcomes > batchLimit {
+				Logger.revisionRecord.warning(
+					"Attempting to save a large amount of \(numberOfOutcomes) Outcomes to the server, please ensure your server supports transactions of this size"
+				)
+			}
+			let results = try await outcomes.createAll(
+				batchLimit: numberOfOutcomes,
+				options: options
+			)
+			results.forEach { result in
+				switch result {
+				case .success:
+					return
+				case .failure(let error):
+					if error.equalsTo(.duplicateValue) {
+						Logger.revisionRecord.warning(
+							"\(duplicateErrorString)"
+						)
+					} else {
+						Logger.revisionRecord.error("Failed to save revision record: \(error)")
+					}
+				}
+			}
+		} catch let parseError as ParseError {
+			if parseError.equalsTo(.duplicateValue) {
+				Logger.revisionRecord.warning(
+					"\(duplicateErrorString). Verify the following Outcomes are already on the server: \(outcomeObjectIDs)"
+				)
+			} else {
+				Logger.revisionRecord.error("Failed to save revision record: \(parseError)")
+			}
+		}
         try await self.create(
 			options: options
 		)

--- a/Sources/ParseCareKit/ParseCareKitLog.swift
+++ b/Sources/ParseCareKit/ParseCareKitLog.swift
@@ -53,6 +53,7 @@ extension Logger {
     static let syncProgress = Logger(subsystem: subsystem, category: "\(category).syncProgress")
     static let clock = Logger(subsystem: subsystem, category: "\(category).clock")
     static let clockSubscription = Logger(subsystem: subsystem, category: "\(category).clockSubscription")
+	static let revisionRecord = Logger(subsystem: subsystem, category: "\(category).revisionRecord")
     static let defaultACL = Logger(subsystem: subsystem, category: "\(category).defaultACL")
     static let initializer = Logger(subsystem: subsystem, category: "\(category).initializer")
     static let deinitializer = Logger(subsystem: subsystem, category: "\(category).deinitializer")

--- a/Sources/ParseCareKit/ParseRemote.swift
+++ b/Sources/ParseCareKit/ParseRemote.swift
@@ -35,7 +35,9 @@ public class ParseRemote: OCKRemoteSynchronizable {
     /// The unique identifier of the remote clock.
     public var uuid: UUID!
 
-	/// The batchLimit for sending tansactions to the ParseServer.
+	/// The limit at which ParseCareKit will log a warning about a batch size potentially
+	/// being to large. The framework will attempt to send over this limit, but be sure
+	/// your server supports transactions this large. Defaults to 100.
 	public var batchLimit: Int
 
     /// A dictionary of any custom classes to synchronize between the `CareKitStore` and the Parse Server.
@@ -56,6 +58,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
      Creates an instance of ParseRemote.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
+        - batchLimit: The limit at which `ParseCareKit` will log a warning about a batch size potentially being to large. The framework will attempt to send over this limit, but be sure your server supports transactions this large. Defaults to 100.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
         - subscribeToRemoteUpdates: Automatically receive updates from other devices linked to this Clock.
         Requires `ParseLiveQuery` server to be setup.
@@ -97,6 +100,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
         - defaultACL: The default access control list for which users can access or modify `ParseCareKit`
         objects. If no `defaultACL` is provided, the default is set to read/write for the user who created the data with
         no public read/write access.
+        - batchLimit: The limit at which `ParseCareKit` will log a warning about a batch size potentially being to large. The framework will attempt to send over this limit, but be sure your server supports transactions this large. Defaults to 100.
      - important: This `defaultACL` is not the same as `ParseACL.defaultACL`.
      - note: If you want the the `ParseCareKit` `defaultACL` to match the `ParseACL.defaultACL`,
      you need to provide `ParseACL.defaultACL`.
@@ -125,6 +129,7 @@ public class ParseRemote: OCKRemoteSynchronizable {
      Creates an instance of ParseRemote.
      - Parameters:
         - uuid: The unique identifier of the remote clock.
+        - batchLimit: The limit at which `ParseCareKit` will log a warning about a batch size potentially being to large. The framework will attempt to send over this limit, but be sure your server supports transactions this large. Defaults to 100.
         - auto: If set to `true`, then the store will attempt to synchronize every time it is modified locally.
         - replacePCKStoreClasses: Replace some or all of the default classes that are synchronized
             by passing in the respective Key/Value pairs. Defaults to nil, which uses the standard default entities.
@@ -176,9 +181,11 @@ public class ParseRemote: OCKRemoteSynchronizable {
 
     // MARK: Conformance to OCKRemoteSynchronizable
 
-    public func pullRevisions(since knowledgeVector: OCKRevisionRecord.KnowledgeVector,
-                              mergeRevision: @escaping (OCKRevisionRecord) -> Void,
-                              completion: @escaping (Error?) -> Void) {
+    public func pullRevisions(
+		since knowledgeVector: OCKRevisionRecord.KnowledgeVector,
+		mergeRevision: @escaping (OCKRevisionRecord) -> Void,
+		completion: @escaping (Error?) -> Void
+	) {
 
         Task {
             // 1. Make sure a remote is setup and available.


### PR DESCRIPTION
- [x] Logs a warning when batch size is > 100, but attempt to send transaction anyway
- [x] Logs warning of entities are already on the server, but continues trying to send the rest of the entities
- [x] If any error occurs when sending a revision record, log it and continue with the rest of the record  